### PR TITLE
Modify responsive display

### DIFF
--- a/packages/web/src/common/components/Header/_atomic/Login.tsx
+++ b/packages/web/src/common/components/Header/_atomic/Login.tsx
@@ -13,6 +13,7 @@ const LoginInner = styled(Link)`
   display: flex;
   gap: 8px;
   align-items: center;
+  min-width: fit-content;
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
   font-size: 16px;
   line-height: 20px;

--- a/packages/web/src/styles/themes/responsive.ts
+++ b/packages/web/src/styles/themes/responsive.ts
@@ -13,11 +13,11 @@ const responsive = {
     xs: "320px",
   },
   CONTENT: {
-    xxl: "1120px",
-    xl: "880px",
-    lg: "640px",
+    xxl: "1200px",
+    xl: "1040px",
+    lg: "800px",
     md: "560px",
-    sm: "calc(100% - 40px)",
+    sm: "calc(100% - 30px)",
   },
 };
 


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #68

디자인 수정 사항에 따라 반응형 코드를 수정했습니다.
화면 너비 : 컨텐츠 너비 = 320 : 260, 720 : 560, 960 : 800, 1200 : 1040, 1440 : 1200 입니다.

+ 반응형 테스트 해보다가 로그인 글자가 이상하게 깨지는 부분이 있길래 LoginInner에 min width 추가했습니다.


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="854" alt="스크린샷 2024-12-28 오후 4 24 27" src="https://github.com/user-attachments/assets/fb637d60-f569-418e-8194-5e468d4c7576" />

https://github.com/user-attachments/assets/968fa31b-0561-42ca-ac80-93225e482ba1

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
