### PR TITLE
Impl manager expenditure table

### DIFF
--- a/packages/interface/src/common/enum/budget.enum.ts
+++ b/packages/interface/src/common/enum/budget.enum.ts
@@ -27,6 +27,7 @@ export enum BudgetDivisionExpenseEnum {
   Operating = 1, // 운영비
   Regular, // 정기사업비
   New, // 비정기사업비
+  Undefined, // Empty in Form
 }
 
 // 예산 클래스 E
@@ -47,6 +48,7 @@ export enum BudgetClassExpenseEnum {
   Extra, // 기타비
   Backup, // 예비비
   Incentive, // 격려금
+  Undefined, // CHACHA: for initial form
 }
 
 export enum BudgetDivisionIncomeItemEnum { // 예산 항목

--- a/packages/interface/src/common/enum/meeting.enum.ts
+++ b/packages/interface/src/common/enum/meeting.enum.ts
@@ -20,7 +20,14 @@ export enum AgendaAcceptedStatusEnum {
 export enum DocumentReviewStatusEnum {
   Accepted = 1, // 승인
   Rejected, // 반려
+  ReviseNeeded, // 수정요청
   Progress, // 검토중
+  LateAccepted, // 사후승인
+  ReviewRejected, // 검토반려
+  ReviewAccepted, // 검토승인
+  Unsaved, // 미저장
+  Draft, // 임시저장
+  Revised, // 추가경정
 }
 
 // AssistantPermissionE
@@ -58,6 +65,36 @@ export const getDisplayNameAgendaAcceptedStatusEnum = (
       return "검토중";
     case AgendaAcceptedStatusEnum.LateAccepted:
       return "사후승인";
+    default:
+      return "";
+  }
+};
+
+// Document Review Status E
+export const getDisplayNameDocumentReviewStatusEnum = (
+  status: DocumentReviewStatusEnum | undefined,
+): string => {
+  switch (status) {
+    case DocumentReviewStatusEnum.Accepted:
+      return "승인";
+    case DocumentReviewStatusEnum.Rejected:
+      return "반려";
+    case DocumentReviewStatusEnum.ReviseNeeded:
+      return "수정요청";
+    case DocumentReviewStatusEnum.Progress:
+      return "검토중";
+    case DocumentReviewStatusEnum.LateAccepted:
+      return "사후승인";
+    case DocumentReviewStatusEnum.ReviewRejected:
+      return "검토반려";
+    case DocumentReviewStatusEnum.ReviewAccepted:
+      return "검토승인";
+    case DocumentReviewStatusEnum.Unsaved:
+      return "미저장";
+    case DocumentReviewStatusEnum.Draft:
+      return "임시저장";
+    case DocumentReviewStatusEnum.Revised:
+      return "추가경정";
     default:
       return "";
   }

--- a/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
@@ -18,8 +18,11 @@ import TotalTable, {
   TotalProps,
 } from "@sparcs-students/web/features/documents/components/TotalTable";
 import {
-  mockExpenditureData,
   // mockExpenditureData,
+  // mockManagerExpenditureData,
+  // mockManagerIncomeData,
+  // mockManagerProjectNameCandidateList,
+  mockExpenditureData,
   // mockManagerIncomeData,
   // mockIncomeData,
   // mockIncomeManagerData,
@@ -42,7 +45,7 @@ import Modal from "@sparcs-students/web/common/components/Modal";
 import ConfirmModalContent from "@sparcs-students/web/common/components/Modal/ConfirmModalContent";
 import CancellableModalContent from "@sparcs-students/web/common/components/Modal/CancellableModalContent";
 import { BudgetDomainEnum } from "@sparcs-students/interface/common/enum/budget.enum";
-// import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
+// import ManagerExpenditureTable from "@sparcs-students/web/features/documents/components/ManagerExpenditureTable";
 import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
 
 interface DomainAccum {
@@ -239,6 +242,12 @@ const Proposal = () => {
         {userPermission === 2 && (
           <ReviewerExpenditureTable initialData={mockExpenditureData} />
         )}
+        {/* {userPermission === 3 && ( */}
+        {/*   <ManagerExpenditureTable */}
+        {/*     initialData={mockManagerExpenditureData} */}
+        {/*     projectNameCandidate={mockManagerProjectNameCandidateList} */}
+        {/*   /> */}
+        {/* )} */}
         <TotalTable
           data={dataToTotal(mockViewerIncomeData, mockViewerExpenditureData)}
         />

--- a/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
@@ -235,7 +235,7 @@ const Proposal = () => {
           <ReviewerIncomeTable initialData={mockViewerIncomeData} />
         )}
         {/* {userPermission === 3 && ( */}
-        {/*   <ManagerIncomeTable initialData={mockManagerIncomeData} /> */}
+        {/*   <ManagerIncomeTable initialData={mockManagerIncomeData} isProposal /> */}
         {/* )} */}
 
         {/* {userPermission === 1 && <ViewerExpenditureTable data={mockViewerExpenditureData} />} */}
@@ -246,6 +246,7 @@ const Proposal = () => {
         {/*   <ManagerExpenditureTable */}
         {/*     initialData={mockManagerExpenditureData} */}
         {/*     projectNameCandidate={mockManagerProjectNameCandidateList} */}
+        {/*     isProposal */}
         {/*   /> */}
         {/* )} */}
         <TotalTable

--- a/packages/web/src/common/components/Forms/TableTextInput.tsx
+++ b/packages/web/src/common/components/Forms/TableTextInput.tsx
@@ -21,8 +21,8 @@ export const errorBorderStyle = css`
 `;
 
 export const disabledStyle = css`
-  background-color: ${({ theme }) => theme.colors.GRAY[50]};
-  border-color: ${({ theme }) => theme.colors.GRAY[100]};
+  //background-color: ${({ theme }) => theme.colors.GRAY[50]};
+  //border-color: ${({ theme }) => theme.colors.GRAY[100]};
 `;
 
 const constantStyle = css`
@@ -102,7 +102,6 @@ const TableTextInput: React.FC<TextInputProps> = ({
     }
 
     handleChange(inputValue);
-    console.log(inputValue);
   };
 
   useEffect(() => {

--- a/packages/web/src/common/components/InputSelect/index.tsx
+++ b/packages/web/src/common/components/InputSelect/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import isPropValid from "@emotion/is-prop-valid";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import FormError from "../FormError";
 import Label from "../FormLabel";
@@ -39,12 +39,12 @@ const SelectInner = styled.div`
   height: fit-content;
 `;
 
-const disabledStyle = css`
-  background-color: ${({ theme }) => theme.colors.GRAY[100]};
-  border-color: ${({ theme }) => theme.colors.GRAY[200]};
-  color: ${({ theme }) => theme.colors.GRAY[400]};
-  pointer-events: none;
-`;
+// const disabledStyle = css`
+//   background-color: ${({ theme }) => theme.colors.GRAY[100]};
+//   border-color: ${({ theme }) => theme.colors.GRAY[200]};
+//   color: ${({ theme }) => theme.colors.GRAY[400]};
+//   pointer-events: none;
+// `;
 
 const StyledSelect = styled.div.withConfig({
   shouldForwardProp: prop => isPropValid(prop),
@@ -72,8 +72,6 @@ const StyledSelect = styled.div.withConfig({
     border-color: ${({ theme, isOpen }) =>
       isOpen ? theme.colors.PRIMARY : theme.colors.GRAY[400]};
   }
-
-  ${({ disabled }) => disabled && disabledStyle}
 `;
 
 const IconWrapperDown = styled.div`
@@ -180,44 +178,73 @@ const Select = ({
                 value={value}
                 handleChange={onChange}
               />
-              {isOpen ? (
-                <IconWrapperUp onClick={handleSelectClick}>
-                  <Icon type="arrow_back_ios_new" size={18} />
-                </IconWrapperUp>
-              ) : (
-                <IconWrapperDown onClick={handleSelectClick}>
-                  <Icon type="arrow_back_ios_new" size={18} />
-                </IconWrapperDown>
-              )}
+              {!disabled &&
+                (isOpen ? (
+                  <IconWrapperUp onClick={handleSelectClick}>
+                    <Icon type="arrow_back_ios_new" size={18} />
+                  </IconWrapperUp>
+                ) : (
+                  <IconWrapperDown onClick={handleSelectClick}>
+                    <Icon type="arrow_back_ios_new" size={18} />
+                  </IconWrapperDown>
+                ))}
             </StyledSelect>
           )}
-          {(onlyDropdown || isOpen) && (
-            <Dropdown
-              onlyDropdown={onlyDropdown}
-              marginTop={15}
-              height={dropdownHeight}
-            >
-              {items.length > 0 ? (
-                items.map(item => (
-                  <SelectOption
-                    key={item.value as string}
-                    selectable={
-                      item.selectable || item.selectable === undefined
-                    }
-                    onClick={() => {
-                      handleOptionClick(item);
-                      onChange(item.label);
-                    }}
-                    selected={value === item.label}
-                  >
-                    {item.label}
-                  </SelectOption>
-                ))
-              ) : (
-                <NoOption>{noOptionMessage}</NoOption>
+          {isRequired && hasOpenedOnce && !value && items.length > 0
+            ? (onlyDropdown || isOpen) && (
+                <Dropdown
+                  onlyDropdown={onlyDropdown}
+                  marginTop={28}
+                  height={dropdownHeight}
+                >
+                  {items.length > 0 ? (
+                    items.map(item => (
+                      <SelectOption
+                        key={item.value as string}
+                        selectable={
+                          item.selectable || item.selectable === undefined
+                        }
+                        onClick={() => {
+                          handleOptionClick(item);
+                          onChange(item.label);
+                        }}
+                        selected={value === item.label}
+                      >
+                        {item.label}
+                      </SelectOption>
+                    ))
+                  ) : (
+                    <NoOption>{noOptionMessage}</NoOption>
+                  )}
+                </Dropdown>
+              )
+            : (onlyDropdown || isOpen) && (
+                <Dropdown
+                  onlyDropdown={onlyDropdown}
+                  marginTop={14}
+                  height={dropdownHeight}
+                >
+                  {items.length > 0 ? (
+                    items.map(item => (
+                      <SelectOption
+                        key={item.value as string}
+                        selectable={
+                          item.selectable || item.selectable === undefined
+                        }
+                        onClick={() => {
+                          handleOptionClick(item);
+                          onChange(item.label);
+                        }}
+                        selected={value === item.label}
+                      >
+                        {item.label}
+                      </SelectOption>
+                    ))
+                  ) : (
+                    <NoOption>{noOptionMessage}</NoOption>
+                  )}
+                </Dropdown>
               )}
-            </Dropdown>
-          )}
         </SelectInner>
         {isRequired && hasOpenedOnce && !value && items.length > 0 && (
           <FormError>

--- a/packages/web/src/common/components/Tag/DarkTag.tsx
+++ b/packages/web/src/common/components/Tag/DarkTag.tsx
@@ -14,6 +14,24 @@ export type DarkTagColor =
   | "TEAL"
   | "YELLOW";
 
+const darkTagColors = [
+  "MAROON",
+  "MARINE",
+  "LEMON",
+  "MELON",
+  "CYAN",
+  "ORCHID",
+  "BLUE",
+  "RED500",
+  "RED700",
+  "TEAL",
+  "YELLOW",
+] as const;
+
+export function isDarkTagColor(value: string): value is DarkTagColor {
+  return darkTagColors.includes(value as DarkTagColor);
+}
+
 const TagInner = styled.div<{ color: DarkTagColor; width: string }>`
   position: relative;
   width: ${({ width }) => width};

--- a/packages/web/src/common/components/TagSelect/index.tsx
+++ b/packages/web/src/common/components/TagSelect/index.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import isPropValid from "@emotion/is-prop-valid";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
+import DarkTag, {
+  DarkTagColor,
+} from "@sparcs-students/web/common/components/Tag/DarkTag";
 import FormError from "../FormError";
 import Label from "../FormLabel";
 
@@ -16,7 +19,7 @@ export interface TagSelectItem<T> {
   label: string;
   value: T;
   selectable?: boolean;
-  color: LightTagColor;
+  color: LightTagColor | DarkTagColor;
 }
 
 interface TagSelectProps<T> {
@@ -33,6 +36,7 @@ interface TagSelectProps<T> {
   onlyDropdown?: boolean;
   dropdownHeight?: number;
   width?: string;
+  isLight?: boolean;
 }
 
 const SelectInner = styled.div`
@@ -40,13 +44,6 @@ const SelectInner = styled.div`
   position: relative;
   height: 24px;
   overflow-y: visible;
-`;
-
-const disabledStyle = css`
-  background-color: ${({ theme }) => theme.colors.GRAY[100]};
-  border-color: ${({ theme }) => theme.colors.GRAY[200]};
-  color: ${({ theme }) => theme.colors.GRAY[400]};
-  pointer-events: none;
 `;
 
 const StyledSelect = styled.div.withConfig({
@@ -75,8 +72,6 @@ const StyledSelect = styled.div.withConfig({
     border-color: ${({ theme, isOpen }) =>
       isOpen ? theme.colors.PRIMARY : theme.colors.GRAY[400]};
   }
-
-  ${({ disabled }) => disabled && disabledStyle}
 `;
 
 const IconWrapperDown = styled.div`
@@ -140,6 +135,7 @@ const TagSelect = <T,>({
   onlyDropdown = false,
   dropdownHeight = undefined,
   width = undefined,
+  isLight = true,
 }: TagSelectProps<T>) => {
   const [isOpen, setIsOpen] = useState(false);
   const [hasOpenedOnce, setHasOpenedOnce] = useState(false);
@@ -208,31 +204,58 @@ const TagSelect = <T,>({
               onClick={handleSelectClick}
               isOpen={isOpen}
             >
-              <SelectValue
-                isSelected={value != null && value !== ""}
-                disabled={disabled}
-                width={width}
-              >
-                {" "}
-                {selectedItem ? (
-                  <LightTag width="100%" color={selectedItem?.color}>
-                    {selectedItem?.label}
-                  </LightTag>
-                ) : (
-                  <LightTag width="100%" color="GRAY">
-                    -
-                  </LightTag>
-                )}
-              </SelectValue>
-              {isOpen ? (
-                <IconWrapperUp>
-                  <Icon type="arrow_back_ios_new" size={18} />
-                </IconWrapperUp>
+              {isLight ? (
+                <SelectValue
+                  isSelected={value != null && value !== ""}
+                  disabled={disabled}
+                  width={width}
+                >
+                  {" "}
+                  {selectedItem ? (
+                    <LightTag
+                      width="100%"
+                      color={selectedItem?.color as LightTagColor}
+                    >
+                      {selectedItem?.label}
+                    </LightTag>
+                  ) : (
+                    <LightTag width="100%" color="GRAY">
+                      -
+                    </LightTag>
+                  )}
+                </SelectValue>
               ) : (
-                <IconWrapperDown>
-                  <Icon type="arrow_back_ios_new" size={18} />
-                </IconWrapperDown>
+                <SelectValue
+                  isSelected={value != null && value !== ""}
+                  disabled={disabled}
+                  width={width}
+                >
+                  {" "}
+                  {selectedItem ? (
+                    <DarkTag
+                      width="100%"
+                      color={selectedItem?.color as DarkTagColor}
+                    >
+                      {selectedItem?.label}
+                    </DarkTag>
+                  ) : (
+                    <LightTag width="100%" color="GRAY">
+                      -
+                    </LightTag>
+                  )}
+                </SelectValue>
               )}
+
+              {!disabled &&
+                (isOpen ? (
+                  <IconWrapperUp>
+                    <Icon type="arrow_back_ios_new" size={18} />
+                  </IconWrapperUp>
+                ) : (
+                  <IconWrapperDown>
+                    <Icon type="arrow_back_ios_new" size={18} />
+                  </IconWrapperDown>
+                ))}
             </StyledSelect>
           )}
           {(onlyDropdown || isOpen) && (
@@ -252,9 +275,18 @@ const TagSelect = <T,>({
                     onClick={() => handleOptionClick(item)}
                     selected={selectedLabel === item.label}
                   >
-                    <LightTag width="100%" color={item.color}>
-                      {item.label}
-                    </LightTag>
+                    {isLight ? (
+                      <LightTag
+                        width="100%"
+                        color={item.color as LightTagColor}
+                      >
+                        {item.label}
+                      </LightTag>
+                    ) : (
+                      <DarkTag width="100%" color={item.color as DarkTagColor}>
+                        {item.label}
+                      </DarkTag>
+                    )}
                   </SelectOption>
                 ))
               ) : (

--- a/packages/web/src/features/budget/components/ManagerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ManagerIncomeTable.tsx
@@ -45,19 +45,8 @@ import { ManagerIncomeProps } from "@sparcs-students/web/features/budget/service
 import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import Icon from "@sparcs-students/web/common/components/Icon";
 import isPropValid from "@emotion/is-prop-valid";
-
-export interface IncomeProps {
-  code: number;
-  budgetDomain: BudgetDomainEnum;
-  budgetDivisionIncome: BudgetDivisionIncomeEnum | undefined;
-  item: string;
-  lastYear: number;
-  thisYear: number;
-  ratio: number | null;
-  reason: string;
-  status: string;
-  review: string;
-}
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
+import colors from "@sparcs-students/web/styles/themes/colors";
 
 interface FormValues {
   incomes: ManagerIncomeProps[];
@@ -74,12 +63,14 @@ interface TableRowProps {
   changeCode: () => void;
   deleteRow: (rowIndex: number) => void;
   isLast: boolean;
+  fieldsLength: number;
 }
 
 const TableWrapper = styled.table`
   position: relative;
   height: fit-content;
   overflow-y: visible;
+  border-collapse: collapse;
 `;
 
 const TableHeader = styled.thead``;
@@ -90,7 +81,7 @@ const TableHeaderWrapper = styled.tr`
   align-items: center;
   border-radius: 4px 4px 0px 0px;
   overflow: hidden;
-  width: 100%;
+  width: fit-content;
 `;
 
 const TableContentWrapper = styled.tbody`
@@ -103,7 +94,7 @@ const TableRowWrapper = styled.tr.withConfig({
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
+  //justify-content: center;
   border-radius: ${({ isLast }) => (isLast ? "0px 0px 4px 4px" : "0px")};
   border-right: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
   border-bottom: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
@@ -111,6 +102,7 @@ const TableRowWrapper = styled.tr.withConfig({
   background: ${({ theme }) => theme.colors.WHITE};
   cursor: pointer;
   overflow-y: visible;
+  width: fit-content;
 `;
 
 const TitleWithButtonWrapper = styled.div`
@@ -127,6 +119,7 @@ const TableRow: React.FC<TableRowProps> = ({
   changeCode,
   deleteRow,
   isLast,
+  fieldsLength,
 }) => {
   const [itemList, setItemList] = useState<SelectItem[]>([]);
 
@@ -153,9 +146,9 @@ const TableRow: React.FC<TableRowProps> = ({
   );
 
   const divisionItemsList = Object.entries(budgetDivisionIncomeTagList).map(
-    ([_, { text, color }]) => ({
+    ([key, { text, color }]) => ({
       label: text,
-      value: text,
+      value: Number(key) as BudgetDivisionIncomeEnum,
       color,
     }),
   );
@@ -173,21 +166,23 @@ const TableRow: React.FC<TableRowProps> = ({
     }
   };
 
-  const getBudgetDivisionIncomeItemsList = (division: string) => {
+  const getBudgetDivisionIncomeItemsList = (
+    division: BudgetDivisionIncomeEnum,
+  ) => {
     switch (division) {
-      case "기층기구회계":
+      case BudgetDivisionIncomeEnum.Substratum:
         return BudgetDivisionIncomeItemEnumList.slice(0, 2);
-      case "중앙회계":
+      case BudgetDivisionIncomeEnum.Central:
         return BudgetDivisionIncomeItemEnumList.slice(2, 4);
-      case "격려기금":
+      case BudgetDivisionIncomeEnum.Incentive:
         return BudgetDivisionIncomeItemEnumList.slice(4, 5);
-      case "학교지원금":
+      case BudgetDivisionIncomeEnum.School:
         return BudgetDivisionIncomeItemEnumList.slice(5, 6);
-      case "이월금":
+      case BudgetDivisionIncomeEnum.Carryover:
         return BudgetDivisionIncomeItemEnumList.slice(6, 7);
-      case "과비":
+      case BudgetDivisionIncomeEnum.Department:
         return BudgetDivisionIncomeItemEnumList.slice(7, 8);
-      case "단비":
+      case BudgetDivisionIncomeEnum.Organizational:
         return BudgetDivisionIncomeItemEnumList.slice(8, 9);
       case undefined:
         return [];
@@ -245,7 +240,7 @@ const TableRow: React.FC<TableRowProps> = ({
 
           return (
             <TableCell type="Default" width="150px">
-              <TagSelect
+              <TagSelect<BudgetDivisionIncomeEnum>
                 items={divisionOptions}
                 value={field.value || divisionOptions[0]}
                 onChange={newVal => {
@@ -368,6 +363,11 @@ const TableRow: React.FC<TableRowProps> = ({
           onClick={() => {
             deleteRow(rowIndex);
           }}
+          color={
+            fieldsLength === 1 && rowIndex === 0
+              ? colors.GRAY["50"]
+              : colors.BLACK
+          }
         />
       </TableCell>
     </TableRowWrapper>
@@ -394,49 +394,14 @@ const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
 
   const incomes = formMethods.watch("incomes");
 
-  const defaultNewRow = [
-    {
-      code: 0,
-      budgetDomain: BudgetDomainEnum.Undefined,
-      budgetDivisionIncome: BudgetDivisionIncomeEnum.Undefined,
-      item: "",
-      lastYear: "",
-      thisYear: "",
-      ratio: 100.0,
-      reason: "",
-      status: "",
-      review: "",
-    },
-  ];
-
-  const addNewRow = () => {
-    const newRow = { ...defaultNewRow[0], id: fields.length };
-    append(newRow);
-
-    const length = incomes.length + 1;
-    setDynamicHeight(36 + length * 48 + 250);
-  };
-
-  const deleteRow = (rowIndex: number) => {
-    if (incomes.length === 1) {
-      return;
-    }
-    remove(rowIndex);
-    const length = incomes.length - 1;
-
-    setDynamicHeight(36 + length * 48 + 250); // TODO: magic number
-  };
-
-  const onSubmit = (data: FormValues) => {
-    console.log("Submitted incomes:", data.incomes);
-  };
-
   const changeCode = () => {
     let studentsFeeCount = 100;
     let schoolFeeCount = 200;
     let autonomousFeeCount = 300;
 
-    incomes.forEach((income, index) => {
+    const updatedIncomes = getValues("incomes");
+
+    updatedIncomes.forEach((income, index) => {
       let newCode = income.code;
 
       switch (income.budgetDomain) {
@@ -463,6 +428,48 @@ const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
     });
   };
 
+  const defaultNewRow = [
+    {
+      code: 0,
+      budgetDomain: BudgetDomainEnum.Undefined,
+      budgetDivisionIncome: BudgetDivisionIncomeEnum.Undefined,
+      item: "",
+      lastYear: "",
+      thisYear: "",
+      ratio: 100.0,
+      reason: "",
+      status: DocumentReviewStatusEnum.Unsaved,
+      review: "",
+    },
+  ];
+
+  const addNewRow = () => {
+    const newRow = { ...defaultNewRow[0], id: fields.length };
+    append(newRow);
+
+    const length = incomes.length + 1;
+    setDynamicHeight(36 + length * 48 + 250);
+  };
+
+  const deleteRow = (rowIndex: number) => {
+    if (incomes.length === 1) {
+      return;
+    }
+    remove(rowIndex);
+    const length = incomes.length - 1;
+
+    setDynamicHeight(36 + length * 48 + 250); // TODO: magic number
+
+    setTimeout(() => {
+      // CHACHA: remove is async. Ensure that changeCode is executed after remove.
+      changeCode();
+    }, 0);
+  };
+
+  const onSubmit = (data: FormValues) => {
+    console.log("Submitted incomes:", data.incomes);
+  };
+
   return (
     <FormProvider {...formMethods}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -472,7 +479,7 @@ const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
               수입
             </Typography>
             <Button type="default" onClick={addNewRow}>
-              추가
+              행 추가
             </Button>
           </TitleWithButtonWrapper>
           <FlexWrapper
@@ -529,6 +536,7 @@ const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
                     rowIndex={index}
                     deleteRow={() => deleteRow(index)}
                     isLast={index === incomes.length - 1}
+                    fieldsLength={fields.length}
                   />
                 ))}
               </TableContentWrapper>

--- a/packages/web/src/features/budget/components/ManagerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ManagerIncomeTable.tsx
@@ -54,6 +54,7 @@ interface FormValues {
 
 interface ManagerIncomeTableProps {
   initialData: ManagerIncomeProps[];
+  isProposal: boolean;
 }
 
 interface TableRowProps {
@@ -376,6 +377,7 @@ const TableRow: React.FC<TableRowProps> = ({
 
 const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
   initialData,
+  isProposal,
 }) => {
   const [dynamicHeight, setDynamicHeight] = React.useState<number | undefined>(
     334, // TODO: magic number 36 + 48 + 250
@@ -504,10 +506,10 @@ const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
                     항목
                   </TableCell>
                   <TableCell type="Header" width="130px">
-                    작년 결산
+                    {isProposal ? "작년 결산" : "예산"}
                   </TableCell>
                   <TableCell type="Header" width="130px">
-                    올해 예산
+                    {isProposal ? "올해 예산" : "결산"}
                   </TableCell>
                   <TableCell type="Header" width="120px">
                     비율

--- a/packages/web/src/features/budget/components/ReviewerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ReviewerIncomeTable.tsx
@@ -28,6 +28,7 @@ import DarkTag, {
   DarkTagColor,
 } from "@sparcs-students/web/common/components/Tag/DarkTag";
 import ReviewButton from "@sparcs-students/web/features/documents/components/_atomic/ReviewButton";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export interface IncomeProps {
   code: number;
@@ -38,7 +39,7 @@ export interface IncomeProps {
   thisYear: number;
   ratio: number | null;
   reason: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
   review: string;
 }
 
@@ -50,7 +51,10 @@ const columnHelper = createColumnHelper<IncomeProps>();
 
 const getColumns = (
   handleReviewChange: (code: number, newReview: string) => void,
-  handleStatusChange: (code: number, newStatus: string) => void,
+  handleStatusChange: (
+    code: number,
+    newStatus: DocumentReviewStatusEnum,
+  ) => void,
 ) => [
   columnHelper.accessor("code", {
     id: "code",
@@ -183,7 +187,10 @@ const ReviewerIncomeTable: React.FC<IncomeTableProps> = ({ initialData }) => {
     );
   };
 
-  const handleStatusChange = (code: number, newStatus: string) => {
+  const handleStatusChange = (
+    code: number,
+    newStatus: DocumentReviewStatusEnum,
+  ) => {
     setData(prevData =>
       prevData.map(item =>
         item.code === code ? { ...item, status: newStatus } : item,

--- a/packages/web/src/features/budget/components/ViewerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ViewerIncomeTable.tsx
@@ -27,6 +27,7 @@ import DetailButton from "@sparcs-students/web/features/documents/components/_at
 import DarkTag, {
   DarkTagColor,
 } from "@sparcs-students/web/common/components/Tag/DarkTag";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export interface ViewerIncomeProps {
   code: number;
@@ -37,7 +38,7 @@ export interface ViewerIncomeProps {
   thisYear: number;
   ratio: number | null;
   reason: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
   review: string;
 }
 

--- a/packages/web/src/features/budget/services/_mock/mockProposalTableData.ts
+++ b/packages/web/src/features/budget/services/_mock/mockProposalTableData.ts
@@ -9,6 +9,8 @@ import { ViewerExpenditureProps } from "@sparcs-students/web/features/documents/
 import { ViewResultProps } from "@sparcs-students/web/features/documents/components/ViewResult";
 import { IncomeProps } from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
 import { ExpenditureProps } from "@sparcs-students/web/features/documents/components/ReviewerExpenditureTable";
+import { ManagerExpenditureProps } from "@sparcs-students/web/features/documents/components/ManagerExpenditureTable";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export const mockViewResultData: ViewResultProps = {
   fileName: "전산학부 24년도 예산안",
@@ -34,7 +36,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
     ratio: 100.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
@@ -47,7 +49,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
     ratio: 100.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
@@ -60,7 +62,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
     ratio: 120.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
@@ -73,7 +75,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
     ratio: 100.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
 ];
@@ -89,7 +91,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
     thisYear: 125000,
     ratio: 100.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
   },
   {
     code: 402,
@@ -101,7 +103,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
     thisYear: 125000,
     ratio: 1000.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
   },
   {
     code: 403,
@@ -113,7 +115,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
     thisYear: 125000,
     ratio: 100.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
   },
   {
     code: 501,
@@ -125,7 +127,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
     thisYear: 125000,
     ratio: 100.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
   },
 ];
 export const mockIncomeData: IncomeProps[] = [
@@ -139,7 +141,7 @@ export const mockIncomeData: IncomeProps[] = [
     ratio: 100.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
@@ -152,7 +154,7 @@ export const mockIncomeData: IncomeProps[] = [
     ratio: 100.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
@@ -165,7 +167,7 @@ export const mockIncomeData: IncomeProps[] = [
     ratio: 120.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
@@ -178,7 +180,7 @@ export const mockIncomeData: IncomeProps[] = [
     ratio: 100.0,
     reason:
       "대충 어쩌구저쩌구한 비고\n아무말이나 적자\nㅁㄴㅇㄹ\nㅁㄴㅇㄻㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
 ];
@@ -192,7 +194,7 @@ export interface ManagerIncomeProps {
   thisYear: number | string;
   ratio: number | null;
   reason: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
   review: string;
 }
 
@@ -206,10 +208,41 @@ export const mockManagerIncomeData: ManagerIncomeProps[] = [
     thisYear: "",
     ratio: 100.0,
     reason: "",
-    status: "",
+    status: DocumentReviewStatusEnum.Unsaved,
     review: "",
   },
 ];
+
+export const mockManagerExpenditureData: ManagerExpenditureProps[] = [
+  {
+    code: 401,
+    budgetDomain: BudgetDomainEnum.Student,
+    budgetDivisionExpenditure: BudgetDivisionExpenseEnum.Operating,
+    projectName: "격려금",
+    item: BudgetClassExpenseEnum.Product,
+    lastYear: "125000",
+    thisYear: "125000",
+    ratio: 100.0,
+    reason: "",
+    status: DocumentReviewStatusEnum.Unsaved,
+    review: "",
+  },
+];
+
+export interface ManagerProjectNameCandidate {
+  budgetDomain: BudgetDomainEnum;
+  budgetDivisionExpenditure: BudgetDivisionExpenseEnum | undefined;
+  projectNameCandidate: string[];
+}
+
+export const mockManagerProjectNameCandidateList: ManagerProjectNameCandidate[] =
+  [
+    {
+      budgetDomain: BudgetDomainEnum.School,
+      budgetDivisionExpenditure: BudgetDivisionExpenseEnum.New,
+      projectNameCandidate: ["작년의 어떠한 사업", "작년의 저떠한 사업"],
+    },
+  ];
 
 export const mockExpenditureData: ExpenditureProps[] = [
   {
@@ -222,7 +255,7 @@ export const mockExpenditureData: ExpenditureProps[] = [
     thisYear: 125000,
     ratio: 100.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
@@ -235,7 +268,7 @@ export const mockExpenditureData: ExpenditureProps[] = [
     thisYear: 125000,
     ratio: 1000.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "수정 요청",
+    status: DocumentReviewStatusEnum.ReviseNeeded,
     review: "",
   },
   {
@@ -248,7 +281,7 @@ export const mockExpenditureData: ExpenditureProps[] = [
     thisYear: 125000,
     ratio: 100.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "반려",
+    status: DocumentReviewStatusEnum.Rejected,
     review: "",
   },
   {
@@ -261,7 +294,7 @@ export const mockExpenditureData: ExpenditureProps[] = [
     thisYear: 125000,
     ratio: 100.0,
     reason: "대충 어쩌구저쩌구한 근거\n아무말이나 적자\nㅁㄴㅇㄹ",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
 ];

--- a/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
@@ -1,0 +1,544 @@
+import React, { useMemo, useState } from "react";
+import {
+  useForm,
+  useFieldArray,
+  FormProvider,
+  Controller,
+  UseFormSetValue,
+  UseFormGetValues,
+} from "react-hook-form";
+
+import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
+import Typography from "@sparcs-students/web/common/components/Typography";
+import LightTag, {
+  LightTagColor,
+} from "@sparcs-students/web/common/components/Tag/LightTag";
+import DarkTag, {
+  DarkTagColor,
+} from "@sparcs-students/web/common/components/Tag/DarkTag";
+import { EditableDetailButton } from "@sparcs-students/web/features/documents/components/_atomic/DetailButton";
+import { ReadOnlyReviewButton } from "@sparcs-students/web/features/documents/components/_atomic/ReviewButton";
+import TagSelect from "@sparcs-students/web/common/components/TagSelect";
+
+import {
+  budgetDivisionIncomeTagList,
+  budgetDomainTagList,
+  getbudgetCodeTag,
+  getbudgetRatioTag,
+  getbudgetStatusTag,
+} from "@sparcs-students/web/features/documents/utils/tableTagList";
+import {
+  BudgetDivisionIncomeEnum,
+  BudgetDomainEnum,
+  BudgetDivisionIncomeItemEnumList,
+  // BudgetDivisionIncomeItemEnum,
+  // DomainItemSelectItem,
+} from "@sparcs-students/interface/common/enum/budget.enum";
+
+import styled from "styled-components";
+import TableCell from "@sparcs-students/web/common/components/Table/TableCell";
+import InputSelect, {
+  SelectItem,
+} from "@sparcs-students/web/common/components/InputSelect"; // SelectItem,
+import TableTextInput from "@sparcs-students/web/common/components/Forms/TableTextInput";
+// import { ManagerIncomeProps } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+import Button from "@sparcs-students/web/common/components/Buttons/Button";
+import Icon from "@sparcs-students/web/common/components/Icon";
+import isPropValid from "@emotion/is-prop-valid";
+
+export interface ManagerExpenditureProps {
+  code: number;
+  budgetDomain: BudgetDomainEnum;
+  budgetDivisionIncome: BudgetDivisionIncomeEnum | undefined;
+  item: string;
+  lastYear: number | string;
+  thisYear: number | string;
+  ratio: number | null;
+  reason: string;
+  status: string;
+  review: string;
+}
+
+interface FormValues {
+  incomes: ManagerExpenditureProps[];
+}
+
+interface ManagerExpenditureTableProps {
+  initialData: ManagerExpenditureProps[];
+}
+
+interface TableRowProps {
+  setValue: UseFormSetValue<FormValues>;
+  getValues: UseFormGetValues<FormValues>;
+  rowIndex: number;
+  changeCode: () => void;
+  deleteRow: (rowIndex: number) => void;
+  isLast: boolean;
+}
+
+const TableWrapper = styled.table`
+  position: relative;
+  height: fit-content;
+  overflow-y: visible;
+`;
+
+const TableHeader = styled.thead``;
+
+const TableHeaderWrapper = styled.tr`
+  display: flex;
+  height: 36px;
+  align-items: center;
+  border-radius: 4px 4px 0px 0px;
+  overflow: hidden;
+  width: 100%;
+`;
+
+const TableContentWrapper = styled.tbody`
+  overflow-y: visible;
+`;
+
+const TableRowWrapper = styled.tr.withConfig({
+  shouldForwardProp: prop => isPropValid(prop),
+})<{ isLast: boolean }>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  border-radius: ${({ isLast }) => (isLast ? "0px 0px 4px 4px" : "0px")};
+  border-right: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
+  border-left: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
+  background: ${({ theme }) => theme.colors.WHITE};
+  cursor: pointer;
+  overflow-y: visible;
+`;
+
+const TitleWithButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: stretch;
+`;
+
+const TableRow: React.FC<TableRowProps> = ({
+  setValue,
+  getValues,
+  rowIndex,
+  changeCode,
+  deleteRow,
+  isLast,
+}) => {
+  const [itemList, setItemList] = useState<SelectItem[]>([]);
+
+  const budgetDomainList = Object.entries(budgetDomainTagList).map(
+    ([key, { text, color }]) => {
+      const value = () => {
+        switch (key) {
+          case "1":
+            return BudgetDomainEnum.Student;
+          case "2":
+            return BudgetDomainEnum.School;
+          case "3":
+            return BudgetDomainEnum.Autonomous;
+          default:
+            return BudgetDomainEnum.Undefined;
+        }
+      };
+      return {
+        label: text,
+        value: value(),
+        color,
+      };
+    },
+  );
+
+  const divisionItemsList = Object.entries(budgetDivisionIncomeTagList).map(
+    ([_, { text, color }]) => ({
+      label: text,
+      value: text,
+      color,
+    }),
+  );
+
+  const getDivisionItemsList = (newValue: BudgetDomainEnum) => {
+    switch (newValue) {
+      case 1:
+        return divisionItemsList.slice(0, 4);
+      case 2:
+        return divisionItemsList.slice(4, 5);
+      case 3:
+        return divisionItemsList.slice(5, 11);
+      default:
+        return [];
+    }
+  };
+
+  const getBudgetDivisionIncomeItemsList = (division: string) => {
+    switch (division) {
+      case "기층기구회계":
+        return BudgetDivisionIncomeItemEnumList.slice(0, 2);
+      case "중앙회계":
+        return BudgetDivisionIncomeItemEnumList.slice(2, 4);
+      case "격려기금":
+        return BudgetDivisionIncomeItemEnumList.slice(4, 5);
+      case "학교지원금":
+        return BudgetDivisionIncomeItemEnumList.slice(5, 6);
+      case "이월금":
+        return BudgetDivisionIncomeItemEnumList.slice(6, 7);
+      case "과비":
+        return BudgetDivisionIncomeItemEnumList.slice(7, 8);
+      case "단비":
+        return BudgetDivisionIncomeItemEnumList.slice(8, 9);
+      case undefined:
+        return [];
+      default:
+        return [];
+    }
+  };
+
+  return (
+    <TableRowWrapper isLast={isLast}>
+      <Controller
+        name={`incomes.${rowIndex}.code`}
+        render={({ field }) => {
+          const { color, text } = getbudgetCodeTag(field.value);
+          return (
+            <TableCell type="Default" width="130px">
+              <LightTag color={color as LightTagColor}>{text}</LightTag>
+            </TableCell>
+          );
+        }}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.budgetDomain`}
+        render={({ field }) => (
+          <TableCell type="Default" width="120px">
+            <TagSelect<BudgetDomainEnum>
+              items={budgetDomainList.slice(0, 3)}
+              value={field.value || "-"}
+              onChange={newValue => {
+                setValue(`incomes.${rowIndex}.budgetDomain`, newValue);
+                setValue(
+                  `incomes.${rowIndex}.budgetDivisionIncome`,
+                  BudgetDivisionIncomeEnum.Undefined,
+                );
+                field.onChange(newValue);
+                changeCode();
+              }}
+              placeholder="-"
+              errorMessage="필수 항목입니다."
+              width="65px"
+            />
+          </TableCell>
+        )}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.budgetDivisionIncome`}
+        render={({ field }) => {
+          const divisionOptions = useMemo(
+            () =>
+              getDivisionItemsList(
+                getValues(`incomes.${rowIndex}.budgetDomain`),
+              ),
+            [getValues(`incomes.${rowIndex}.budgetDomain`)],
+          );
+
+          return (
+            <TableCell type="Default" width="150px">
+              <TagSelect
+                items={divisionOptions}
+                value={field.value || divisionOptions[0]}
+                onChange={newVal => {
+                  setItemList(getBudgetDivisionIncomeItemsList(newVal));
+                  setValue(`incomes.${rowIndex}.item`, "");
+                  field.onChange(newVal);
+                }}
+                placeholder="-"
+                errorMessage="필수 항목입니다."
+                width="90px"
+              />
+            </TableCell>
+          );
+        }}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.item`}
+        render={({ field }) => (
+          <TableCell type="Default" width="400px">
+            <InputSelect
+              items={itemList}
+              value={field.value}
+              onChange={newVal => field.onChange(newVal)}
+              errorMessage="필수 항목입니다."
+            />
+          </TableCell>
+        )}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.lastYear`}
+        render={({ field }) => (
+          <TableCell type="Default" width="130px">
+            <TableTextInput
+              value={field.value}
+              handleChange={newVal => field.onChange(newVal)}
+              placeholder="금액 입력"
+              prefix="₩"
+            />
+          </TableCell>
+        )}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.thisYear`}
+        render={({ field }) => (
+          <TableCell type="Default" width="130px">
+            <TableTextInput
+              value={field.value}
+              handleChange={newVal => field.onChange(newVal)}
+              placeholder="금액 입력"
+              prefix="₩"
+            />
+          </TableCell>
+        )}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.ratio`}
+        render={() => {
+          const lastYear = parseInt(
+            getValues(`incomes.${rowIndex}.lastYear`) as unknown as string,
+          );
+          const thisYear = parseInt(
+            getValues(`incomes.${rowIndex}.thisYear`) as unknown as string,
+          );
+          const ratio = useMemo(() => {
+            if (lastYear <= 0) {
+              return null;
+            }
+            return (thisYear / lastYear) * 100;
+          }, [lastYear, thisYear]);
+          const { color, text } = getbudgetRatioTag(ratio);
+          return (
+            <TableCell type="Default" width="120px">
+              <LightTag color={color as LightTagColor}>{text}</LightTag>
+            </TableCell>
+          );
+        }}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.reason`}
+        render={({ field }) => {
+          const projectItem = getValues(`incomes.${rowIndex}.item`);
+          return (
+            <TableCell type="Default" width="90px">
+              <EditableDetailButton
+                projectItem={projectItem}
+                value={field.value}
+                onChange={field.onChange}
+              />
+            </TableCell>
+          );
+        }}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.status`}
+        render={({ field }) => {
+          const { color, text } = getbudgetStatusTag(field.value);
+          return (
+            <TableCell type="Default" width="100px">
+              {color !== "GRAY" ? (
+                <DarkTag color={color as DarkTagColor}>{text}</DarkTag>
+              ) : (
+                <LightTag color={color as LightTagColor}>{text}</LightTag>
+              )}
+            </TableCell>
+          );
+        }}
+      />
+      <Controller
+        name={`incomes.${rowIndex}.review`}
+        render={({ field }) => (
+          <TableCell type="Default" width="90px">
+            <ReadOnlyReviewButton review={field.value} />
+          </TableCell>
+        )}
+      />
+      <TableCell type="Default" width="90px">
+        <Icon
+          type="delete"
+          size={16}
+          onClick={() => {
+            deleteRow(rowIndex);
+          }}
+        />
+      </TableCell>
+    </TableRowWrapper>
+  );
+};
+
+const ManagerIncomeTable: React.FC<ManagerExpenditureTableProps> = ({
+  initialData,
+}) => {
+  const [dynamicHeight, setDynamicHeight] = React.useState<number | undefined>(
+    334, // TODO: magic number 36 + 48 + 250
+  );
+  const formMethods = useForm<FormValues>({
+    defaultValues: {
+      incomes: initialData,
+    },
+  });
+
+  const { handleSubmit, control, setValue, getValues } = formMethods;
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "incomes",
+  });
+
+  const incomes = formMethods.watch("incomes");
+
+  const defaultNewRow = [
+    {
+      code: 0,
+      budgetDomain: BudgetDomainEnum.Undefined,
+      budgetDivisionIncome: BudgetDivisionIncomeEnum.Undefined,
+      item: "",
+      lastYear: "",
+      thisYear: "",
+      ratio: 100.0,
+      reason: "",
+      status: "",
+      review: "",
+    },
+  ];
+
+  const addNewRow = () => {
+    const newRow = { ...defaultNewRow[0], id: fields.length };
+    append(newRow);
+
+    const length = incomes.length + 1;
+    setDynamicHeight(36 + length * 48 + 250);
+  };
+
+  const deleteRow = (rowIndex: number) => {
+    if (incomes.length === 1) {
+      return;
+    }
+    remove(rowIndex);
+    const length = incomes.length - 1;
+
+    setDynamicHeight(36 + length * 48 + 250); // TODO: magic number
+  };
+
+  const onSubmit = (data: FormValues) => {
+    console.log("Submitted incomes:", data.incomes);
+  };
+
+  const changeCode = () => {
+    let studentsFeeCount = 100;
+    let schoolFeeCount = 200;
+    let autonomousFeeCount = 300;
+
+    incomes.forEach((income, index) => {
+      let newCode = income.code;
+
+      switch (income.budgetDomain) {
+        case 1:
+          studentsFeeCount += 1;
+          newCode = studentsFeeCount;
+          break;
+        case 2:
+          schoolFeeCount += 1;
+          newCode = schoolFeeCount;
+          break;
+        case 3:
+          autonomousFeeCount += 1;
+          newCode = autonomousFeeCount;
+          break;
+        default:
+          newCode = 0;
+          break;
+      }
+
+      setValue(`incomes.${index}.code`, newCode, {
+        shouldValidate: true,
+      });
+    });
+  };
+
+  return (
+    <FormProvider {...formMethods}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <FlexWrapper direction="column" gap={16}>
+          <TitleWithButtonWrapper>
+            <Typography fs={24} lh={30} color="BLACK" fw="SEMIBOLD">
+              수입
+            </Typography>
+            <Button type="default" onClick={addNewRow}>
+              추가
+            </Button>
+          </TitleWithButtonWrapper>
+          <FlexWrapper
+            direction="column"
+            gap={16}
+            height={`${dynamicHeight}px`}
+            xOverflow
+          >
+            <TableWrapper>
+              <TableHeader>
+                <TableHeaderWrapper>
+                  <TableCell type="Header" width="130px">
+                    코드
+                  </TableCell>
+                  <TableCell type="Header" width="120px">
+                    구분
+                  </TableCell>
+                  <TableCell type="Header" width="150px">
+                    예산 분류
+                  </TableCell>
+                  <TableCell type="Header" width="400px">
+                    항목
+                  </TableCell>
+                  <TableCell type="Header" width="130px">
+                    작년 결산
+                  </TableCell>
+                  <TableCell type="Header" width="130px">
+                    올해 예산
+                  </TableCell>
+                  <TableCell type="Header" width="120px">
+                    비율
+                  </TableCell>
+                  <TableCell type="Header" width="90px">
+                    비고
+                  </TableCell>
+                  <TableCell type="Header" width="100px">
+                    현황
+                  </TableCell>
+                  <TableCell type="Header" width="90px">
+                    검토
+                  </TableCell>
+                  <TableCell type="Header" width="90px">
+                    삭제
+                  </TableCell>
+                </TableHeaderWrapper>
+              </TableHeader>
+              <TableContentWrapper>
+                {fields.map((field, index) => (
+                  <TableRow
+                    changeCode={changeCode}
+                    setValue={setValue}
+                    getValues={getValues}
+                    key={field.id}
+                    rowIndex={index}
+                    deleteRow={() => deleteRow(index)}
+                    isLast={index === incomes.length - 1}
+                  />
+                ))}
+              </TableContentWrapper>
+            </TableWrapper>
+            {/* <button type="submit">Submit</button> for console */}
+          </FlexWrapper>
+        </FlexWrapper>
+      </form>
+    </FormProvider>
+  );
+};
+
+export default ManagerIncomeTable;

--- a/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
@@ -76,6 +76,7 @@ interface FormValues {
 interface ManagerExpenditureTableProps {
   initialData: ManagerExpenditureProps[];
   projectNameCandidate: ManagerProjectNameCandidate[];
+  isProposal: boolean;
 }
 
 interface TableRowProps {
@@ -420,6 +421,7 @@ const TableRow: React.FC<TableRowProps> = ({
 const ManagerExpenditureTable: React.FC<ManagerExpenditureTableProps> = ({
   initialData,
   projectNameCandidate,
+  isProposal,
 }) => {
   const [dynamicHeight, setDynamicHeight] = React.useState<number | undefined>(
     334, // TODO: magic number 36 + 48 + 250
@@ -552,10 +554,10 @@ const ManagerExpenditureTable: React.FC<ManagerExpenditureTableProps> = ({
                     항목
                   </TableCell>
                   <TableCell type="Header" width="130px">
-                    작년 결산
+                    {isProposal ? "작년 결산" : "예산"}
                   </TableCell>
                   <TableCell type="Header" width="130px">
-                    올해 예산
+                    {isProposal ? "올해 예산" : "결산"}
                   </TableCell>
                   <TableCell type="Header" width="120px">
                     비율

--- a/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import {
-  useForm,
-  useFieldArray,
-  FormProvider,
   Controller,
-  UseFormSetValue,
+  FormProvider,
+  useFieldArray,
+  useForm,
   UseFormGetValues,
+  UseFormSetValue,
 } from "react-hook-form";
 
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
@@ -21,50 +21,61 @@ import { ReadOnlyReviewButton } from "@sparcs-students/web/features/documents/co
 import TagSelect from "@sparcs-students/web/common/components/TagSelect";
 
 import {
-  budgetDivisionIncomeTagList,
+  budgetClassExpenseTagList,
+  budgetDivisionExpenseTagList,
   budgetDomainTagList,
   getbudgetCodeTag,
   getbudgetRatioTag,
   getbudgetStatusTag,
 } from "@sparcs-students/web/features/documents/utils/tableTagList";
 import {
-  BudgetDivisionIncomeEnum,
+  BudgetClassExpenseEnum,
+  BudgetDivisionExpenseEnum,
   BudgetDomainEnum,
-  BudgetDivisionIncomeItemEnumList,
-  // BudgetDivisionIncomeItemEnum,
-  // DomainItemSelectItem,
 } from "@sparcs-students/interface/common/enum/budget.enum";
 
 import styled from "styled-components";
 import TableCell from "@sparcs-students/web/common/components/Table/TableCell";
-import InputSelect, {
-  SelectItem,
-} from "@sparcs-students/web/common/components/InputSelect"; // SelectItem,
+import InputSelect from "@sparcs-students/web/common/components/InputSelect"; // SelectItem,
 import TableTextInput from "@sparcs-students/web/common/components/Forms/TableTextInput";
 // import { ManagerIncomeProps } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
 import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import Icon from "@sparcs-students/web/common/components/Icon";
 import isPropValid from "@emotion/is-prop-valid";
+import {
+  DarkStatusDetail,
+  StatusDetail,
+} from "@sparcs-students/web/utils/getTagDetail";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
+import colors from "@sparcs-students/web/styles/themes/colors";
 
 export interface ManagerExpenditureProps {
   code: number;
   budgetDomain: BudgetDomainEnum;
-  budgetDivisionIncome: BudgetDivisionIncomeEnum | undefined;
-  item: string;
+  budgetDivisionExpenditure: BudgetDivisionExpenseEnum | undefined;
+  projectName: string;
+  item: BudgetClassExpenseEnum;
   lastYear: number | string;
   thisYear: number | string;
   ratio: number | null;
   reason: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
   review: string;
 }
 
+export interface ManagerProjectNameCandidate {
+  budgetDomain: BudgetDomainEnum;
+  budgetDivisionExpenditure: BudgetDivisionExpenseEnum | undefined;
+  projectNameCandidate: string[];
+}
+
 interface FormValues {
-  incomes: ManagerExpenditureProps[];
+  expenditures: ManagerExpenditureProps[];
 }
 
 interface ManagerExpenditureTableProps {
   initialData: ManagerExpenditureProps[];
+  projectNameCandidate: ManagerProjectNameCandidate[];
 }
 
 interface TableRowProps {
@@ -74,12 +85,14 @@ interface TableRowProps {
   changeCode: () => void;
   deleteRow: (rowIndex: number) => void;
   isLast: boolean;
+  projectNameCandidate: ManagerProjectNameCandidate[];
 }
 
 const TableWrapper = styled.table`
   position: relative;
   height: fit-content;
   overflow-y: visible;
+  border-collapse: collapse;
 `;
 
 const TableHeader = styled.thead``;
@@ -90,7 +103,7 @@ const TableHeaderWrapper = styled.tr`
   align-items: center;
   border-radius: 4px 4px 0px 0px;
   overflow: hidden;
-  width: 100%;
+  width: fit-content;
 `;
 
 const TableContentWrapper = styled.tbody`
@@ -103,7 +116,6 @@ const TableRowWrapper = styled.tr.withConfig({
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
   border-radius: ${({ isLast }) => (isLast ? "0px 0px 4px 4px" : "0px")};
   border-right: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
   border-bottom: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
@@ -111,6 +123,7 @@ const TableRowWrapper = styled.tr.withConfig({
   background: ${({ theme }) => theme.colors.WHITE};
   cursor: pointer;
   overflow-y: visible;
+  width: fit-content;
 `;
 
 const TitleWithButtonWrapper = styled.div`
@@ -127,9 +140,8 @@ const TableRow: React.FC<TableRowProps> = ({
   changeCode,
   deleteRow,
   isLast,
+  projectNameCandidate,
 }) => {
-  const [itemList, setItemList] = useState<SelectItem[]>([]);
-
   const budgetDomainList = Object.entries(budgetDomainTagList).map(
     ([key, { text, color }]) => {
       const value = () => {
@@ -152,56 +164,59 @@ const TableRow: React.FC<TableRowProps> = ({
     },
   );
 
-  const divisionItemsList = Object.entries(budgetDivisionIncomeTagList).map(
-    ([_, { text, color }]) => ({
-      label: text,
-      value: text,
-      color,
-    }),
-  );
+  const divisionItemsList = (
+    Object.entries(budgetDivisionExpenseTagList) as unknown as [
+      BudgetDivisionExpenseEnum,
+      StatusDetail,
+    ][]
+  ).map(([key, { text, color }]) => ({
+    label: text,
+    value: Number(key) as BudgetDivisionExpenseEnum,
+    color,
+  }));
 
-  const getDivisionItemsList = (newValue: BudgetDomainEnum) => {
-    switch (newValue) {
-      case 1:
-        return divisionItemsList.slice(0, 4);
-      case 2:
-        return divisionItemsList.slice(4, 5);
-      case 3:
-        return divisionItemsList.slice(5, 11);
-      default:
-        return [];
-    }
+  const divisionItemsClassList = (
+    Object.entries(budgetClassExpenseTagList) as unknown as [
+      BudgetClassExpenseEnum,
+      DarkStatusDetail,
+    ][]
+  ).map(([key, { text, color }]) => ({
+    label: text,
+    value: Number(key) as BudgetClassExpenseEnum,
+    color,
+  }));
+
+  const setProjectNameListInputItem = (foundProjectNameCandidate: string[]) => {
+    const inputItem = foundProjectNameCandidate.map(e => ({
+      label: e,
+      value: e,
+    }));
+    return inputItem;
   };
 
-  const getBudgetDivisionIncomeItemsList = (division: string) => {
-    switch (division) {
-      case "기층기구회계":
-        return BudgetDivisionIncomeItemEnumList.slice(0, 2);
-      case "중앙회계":
-        return BudgetDivisionIncomeItemEnumList.slice(2, 4);
-      case "격려기금":
-        return BudgetDivisionIncomeItemEnumList.slice(4, 5);
-      case "학교지원금":
-        return BudgetDivisionIncomeItemEnumList.slice(5, 6);
-      case "이월금":
-        return BudgetDivisionIncomeItemEnumList.slice(6, 7);
-      case "과비":
-        return BudgetDivisionIncomeItemEnumList.slice(7, 8);
-      case "단비":
-        return BudgetDivisionIncomeItemEnumList.slice(8, 9);
-      case undefined:
-        return [];
-      default:
-        return [];
-    }
+  const getProjectNameCandidateList = () => {
+    if (!projectNameCandidate) return [];
+    const found = projectNameCandidate.find(
+      e =>
+        e.budgetDomain === getValues(`expenditures.${rowIndex}.budgetDomain`) &&
+        e.budgetDivisionExpenditure ===
+          parseInt(
+            getValues(
+              `expenditures.${rowIndex}.budgetDivisionExpenditure`,
+            ) as unknown as string,
+          ),
+    );
+
+    return found?.projectNameCandidate ?? [];
   };
 
   return (
     <TableRowWrapper isLast={isLast}>
       <Controller
-        name={`incomes.${rowIndex}.code`}
+        name={`expenditures.${rowIndex}.code`}
         render={({ field }) => {
           const { color, text } = getbudgetCodeTag(field.value);
+
           return (
             <TableCell type="Default" width="130px">
               <LightTag color={color as LightTagColor}>{text}</LightTag>
@@ -210,77 +225,100 @@ const TableRow: React.FC<TableRowProps> = ({
         }}
       />
       <Controller
-        name={`incomes.${rowIndex}.budgetDomain`}
+        name={`expenditures.${rowIndex}.budgetDomain`}
         render={({ field }) => (
           <TableCell type="Default" width="120px">
             <TagSelect<BudgetDomainEnum>
               items={budgetDomainList.slice(0, 3)}
               value={field.value || "-"}
               onChange={newValue => {
-                setValue(`incomes.${rowIndex}.budgetDomain`, newValue);
-                setValue(
-                  `incomes.${rowIndex}.budgetDivisionIncome`,
-                  BudgetDivisionIncomeEnum.Undefined,
-                );
+                if (rowIndex === 0) return;
+                setValue(`expenditures.${rowIndex}.budgetDomain`, newValue);
                 field.onChange(newValue);
                 changeCode();
+                setValue(`expenditures.${rowIndex}.projectName`, "");
+                setProjectNameListInputItem(getProjectNameCandidateList());
               }}
               placeholder="-"
               errorMessage="필수 항목입니다."
               width="65px"
+              disabled={rowIndex === 0}
             />
           </TableCell>
         )}
       />
       <Controller
-        name={`incomes.${rowIndex}.budgetDivisionIncome`}
-        render={({ field }) => {
-          const divisionOptions = useMemo(
-            () =>
-              getDivisionItemsList(
-                getValues(`incomes.${rowIndex}.budgetDomain`),
-              ),
-            [getValues(`incomes.${rowIndex}.budgetDomain`)],
-          );
-
-          return (
-            <TableCell type="Default" width="150px">
-              <TagSelect
-                items={divisionOptions}
-                value={field.value || divisionOptions[0]}
-                onChange={newVal => {
-                  setItemList(getBudgetDivisionIncomeItemsList(newVal));
-                  setValue(`incomes.${rowIndex}.item`, "");
-                  field.onChange(newVal);
-                }}
-                placeholder="-"
-                errorMessage="필수 항목입니다."
-                width="90px"
-              />
-            </TableCell>
-          );
-        }}
+        name={`expenditures.${rowIndex}.budgetDivisionExpenditure`}
+        render={({ field }) => (
+          <TableCell type="Default" width="150px">
+            <TagSelect<BudgetDivisionExpenseEnum>
+              items={divisionItemsList.slice(0, 3)}
+              value={field.value || divisionItemsList[0].value}
+              onChange={newVal => {
+                if (rowIndex === 0) return;
+                setValue(
+                  `expenditures.${rowIndex}.item`,
+                  BudgetClassExpenseEnum.Undefined,
+                );
+                field.onChange(newVal);
+                setValue(`expenditures.${rowIndex}.projectName`, "");
+                setProjectNameListInputItem(getProjectNameCandidateList());
+              }}
+              placeholder="-"
+              errorMessage="필수 항목입니다."
+              width="90px"
+              disabled={rowIndex === 0}
+            />
+          </TableCell>
+        )}
       />
       <Controller
-        name={`incomes.${rowIndex}.item`}
+        name={`expenditures.${rowIndex}.projectName`}
         render={({ field }) => (
           <TableCell type="Default" width="400px">
             <InputSelect
-              items={itemList}
+              items={setProjectNameListInputItem(getProjectNameCandidateList())}
               value={field.value}
-              onChange={newVal => field.onChange(newVal)}
+              onChange={newVal => {
+                if (rowIndex === 0) return;
+                field.onChange(newVal);
+              }}
               errorMessage="필수 항목입니다."
+              disabled={rowIndex === 0}
             />
           </TableCell>
         )}
       />
       <Controller
-        name={`incomes.${rowIndex}.lastYear`}
+        name={`expenditures.${rowIndex}.item`}
+        render={({ field }) => (
+          <TableCell type="Default" width="142px">
+            <TagSelect<BudgetClassExpenseEnum>
+              items={divisionItemsClassList.slice(0, 16)}
+              value={field.value || divisionItemsClassList[0]}
+              onChange={newVal => {
+                if (rowIndex === 0) return;
+                field.onChange(newVal);
+              }}
+              placeholder="-"
+              errorMessage="필수 항목입니다."
+              width="90px"
+              isLight={false} // DarkTag is used.
+              disabled={rowIndex === 0}
+            />
+          </TableCell>
+        )}
+      />
+      <Controller
+        name={`expenditures.${rowIndex}.lastYear`}
         render={({ field }) => (
           <TableCell type="Default" width="130px">
             <TableTextInput
               value={field.value}
-              handleChange={newVal => field.onChange(newVal)}
+              handleChange={newVal => {
+                if (rowIndex === 0) return;
+                field.onChange(newVal);
+              }}
               placeholder="금액 입력"
               prefix="₩"
             />
@@ -288,12 +326,15 @@ const TableRow: React.FC<TableRowProps> = ({
         )}
       />
       <Controller
-        name={`incomes.${rowIndex}.thisYear`}
+        name={`expenditures.${rowIndex}.thisYear`}
         render={({ field }) => (
           <TableCell type="Default" width="130px">
             <TableTextInput
               value={field.value}
-              handleChange={newVal => field.onChange(newVal)}
+              handleChange={newVal => {
+                if (rowIndex === 0) return;
+                field.onChange(newVal);
+              }}
               placeholder="금액 입력"
               prefix="₩"
             />
@@ -301,13 +342,13 @@ const TableRow: React.FC<TableRowProps> = ({
         )}
       />
       <Controller
-        name={`incomes.${rowIndex}.ratio`}
+        name={`expenditures.${rowIndex}.ratio`}
         render={() => {
           const lastYear = parseInt(
-            getValues(`incomes.${rowIndex}.lastYear`) as unknown as string,
+            getValues(`expenditures.${rowIndex}.lastYear`) as unknown as string,
           );
           const thisYear = parseInt(
-            getValues(`incomes.${rowIndex}.thisYear`) as unknown as string,
+            getValues(`expenditures.${rowIndex}.thisYear`) as unknown as string,
           );
           const ratio = useMemo(() => {
             if (lastYear <= 0) {
@@ -324,9 +365,9 @@ const TableRow: React.FC<TableRowProps> = ({
         }}
       />
       <Controller
-        name={`incomes.${rowIndex}.reason`}
+        name={`expenditures.${rowIndex}.reason`}
         render={({ field }) => {
-          const projectItem = getValues(`incomes.${rowIndex}.item`);
+          const projectItem = getValues(`expenditures.${rowIndex}.projectName`);
           return (
             <TableCell type="Default" width="90px">
               <EditableDetailButton
@@ -339,7 +380,7 @@ const TableRow: React.FC<TableRowProps> = ({
         }}
       />
       <Controller
-        name={`incomes.${rowIndex}.status`}
+        name={`expenditures.${rowIndex}.status`}
         render={({ field }) => {
           const { color, text } = getbudgetStatusTag(field.value);
           return (
@@ -354,7 +395,7 @@ const TableRow: React.FC<TableRowProps> = ({
         }}
       />
       <Controller
-        name={`incomes.${rowIndex}.review`}
+        name={`expenditures.${rowIndex}.review`}
         render={({ field }) => (
           <TableCell type="Default" width="90px">
             <ReadOnlyReviewButton review={field.value} />
@@ -366,80 +407,48 @@ const TableRow: React.FC<TableRowProps> = ({
           type="delete"
           size={16}
           onClick={() => {
+            if (rowIndex === 0) return;
             deleteRow(rowIndex);
           }}
+          color={rowIndex === 0 ? colors.GRAY["50"] : colors.BLACK}
         />
       </TableCell>
     </TableRowWrapper>
   );
 };
 
-const ManagerIncomeTable: React.FC<ManagerExpenditureTableProps> = ({
+const ManagerExpenditureTable: React.FC<ManagerExpenditureTableProps> = ({
   initialData,
+  projectNameCandidate,
 }) => {
   const [dynamicHeight, setDynamicHeight] = React.useState<number | undefined>(
     334, // TODO: magic number 36 + 48 + 250
   );
+
   const formMethods = useForm<FormValues>({
     defaultValues: {
-      incomes: initialData,
+      expenditures: initialData,
     },
   });
 
   const { handleSubmit, control, setValue, getValues } = formMethods;
   const { fields, append, remove } = useFieldArray({
     control,
-    name: "incomes",
+    name: "expenditures",
   });
 
-  const incomes = formMethods.watch("incomes");
-
-  const defaultNewRow = [
-    {
-      code: 0,
-      budgetDomain: BudgetDomainEnum.Undefined,
-      budgetDivisionIncome: BudgetDivisionIncomeEnum.Undefined,
-      item: "",
-      lastYear: "",
-      thisYear: "",
-      ratio: 100.0,
-      reason: "",
-      status: "",
-      review: "",
-    },
-  ];
-
-  const addNewRow = () => {
-    const newRow = { ...defaultNewRow[0], id: fields.length };
-    append(newRow);
-
-    const length = incomes.length + 1;
-    setDynamicHeight(36 + length * 48 + 250);
-  };
-
-  const deleteRow = (rowIndex: number) => {
-    if (incomes.length === 1) {
-      return;
-    }
-    remove(rowIndex);
-    const length = incomes.length - 1;
-
-    setDynamicHeight(36 + length * 48 + 250); // TODO: magic number
-  };
-
-  const onSubmit = (data: FormValues) => {
-    console.log("Submitted incomes:", data.incomes);
-  };
+  const expenditures = formMethods.watch("expenditures");
 
   const changeCode = () => {
-    let studentsFeeCount = 100;
-    let schoolFeeCount = 200;
-    let autonomousFeeCount = 300;
+    let studentsFeeCount = 400;
+    let schoolFeeCount = 500;
+    let autonomousFeeCount = 600;
 
-    incomes.forEach((income, index) => {
-      let newCode = income.code;
+    const updatedExpenditures = getValues("expenditures");
+    updatedExpenditures.forEach((expenditure, index) => {
+      let newCode = expenditure.code;
 
-      switch (income.budgetDomain) {
+      switch (expenditure.budgetDomain) {
         case 1:
           studentsFeeCount += 1;
           newCode = studentsFeeCount;
@@ -457,10 +466,53 @@ const ManagerIncomeTable: React.FC<ManagerExpenditureTableProps> = ({
           break;
       }
 
-      setValue(`incomes.${index}.code`, newCode, {
+      setValue(`expenditures.${index}.code`, newCode, {
         shouldValidate: true,
       });
     });
+  };
+
+  const defaultNewRow = [
+    {
+      code: 0,
+      budgetDomain: BudgetDomainEnum.Undefined,
+      budgetDivisionExpenditure: BudgetDivisionExpenseEnum.Undefined,
+      projectName: "",
+      item: BudgetClassExpenseEnum.Undefined,
+      lastYear: "",
+      thisYear: "",
+      ratio: 100.0,
+      reason: "",
+      status: DocumentReviewStatusEnum.Unsaved,
+      review: "",
+    },
+  ];
+
+  const addNewRow = () => {
+    const newRow = { ...defaultNewRow[0], id: fields.length };
+    append(newRow);
+
+    const length = expenditures.length + 1;
+    setDynamicHeight(36 + length * 48 + 250);
+  };
+
+  const deleteRow = (rowIndex: number) => {
+    if (expenditures.length === 1) {
+      return;
+    }
+    remove(rowIndex);
+    const length = expenditures.length - 1;
+
+    setDynamicHeight(36 + length * 48 + 250); // TODO: magic number
+
+    setTimeout(() => {
+      // CHACHA: remove is async. Ensure that changeCode is executed after remove.
+      changeCode();
+    }, 0);
+  };
+
+  const onSubmit = (data: FormValues) => {
+    console.log("Submitted incomes:", data.expenditures);
   };
 
   return (
@@ -469,10 +521,10 @@ const ManagerIncomeTable: React.FC<ManagerExpenditureTableProps> = ({
         <FlexWrapper direction="column" gap={16}>
           <TitleWithButtonWrapper>
             <Typography fs={24} lh={30} color="BLACK" fw="SEMIBOLD">
-              수입
+              지출
             </Typography>
             <Button type="default" onClick={addNewRow}>
-              추가
+              행 추가
             </Button>
           </TitleWithButtonWrapper>
           <FlexWrapper
@@ -494,6 +546,9 @@ const ManagerIncomeTable: React.FC<ManagerExpenditureTableProps> = ({
                     예산 분류
                   </TableCell>
                   <TableCell type="Header" width="400px">
+                    사업명
+                  </TableCell>
+                  <TableCell type="Header" width="142px">
                     항목
                   </TableCell>
                   <TableCell type="Header" width="130px">
@@ -528,7 +583,8 @@ const ManagerIncomeTable: React.FC<ManagerExpenditureTableProps> = ({
                     key={field.id}
                     rowIndex={index}
                     deleteRow={() => deleteRow(index)}
-                    isLast={index === incomes.length - 1}
+                    isLast={index === expenditures.length - 1}
+                    projectNameCandidate={projectNameCandidate}
                   />
                 ))}
               </TableContentWrapper>
@@ -541,4 +597,4 @@ const ManagerIncomeTable: React.FC<ManagerExpenditureTableProps> = ({
   );
 };
 
-export default ManagerIncomeTable;
+export default ManagerExpenditureTable;

--- a/packages/web/src/features/documents/components/ReviewModal.tsx
+++ b/packages/web/src/features/documents/components/ReviewModal.tsx
@@ -3,13 +3,14 @@ import React, { useState } from "react";
 import styled, { useTheme } from "styled-components";
 import Typography from "@sparcs-students/web/common/components/Typography";
 import TextAreaInput from "@sparcs-students/web/common/components/Forms/TextAreaInput";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 interface ReviewModalProps {
   onConfirm: () => void;
   review: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
   handleReviewChange: (detail: string) => void;
-  handleStatusChange: (status: string) => void;
+  handleStatusChange: (status: DocumentReviewStatusEnum) => void;
 }
 
 interface ReadOnlyReviewModalProps {
@@ -74,16 +75,18 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
           <Button
             onClick={() => {
               handleReviewChange(reviewText);
-              handleStatusChange("검토반려");
+              handleStatusChange(DocumentReviewStatusEnum.ReviewRejected);
               onConfirm();
             }}
             type={
-              status === "반려" || status === "검토반려"
+              status === DocumentReviewStatusEnum.Rejected ||
+              status === DocumentReviewStatusEnum.ReviewRejected
                 ? "disabled"
                 : "default"
             }
             style={
-              status === "반려" || status === "검토반려"
+              status === DocumentReviewStatusEnum.Rejected ||
+              status === DocumentReviewStatusEnum.ReviewRejected
                 ? {}
                 : {
                     border: `1px solid ${theme.colors.RED[700]}`,
@@ -97,12 +100,16 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
           <Button
             onClick={() => {
               handleReviewChange(reviewText);
-              handleStatusChange("수정 요청");
+              handleStatusChange(DocumentReviewStatusEnum.ReviseNeeded);
               onConfirm();
             }}
-            type={status === "수정 요청" ? "disabled" : "default"}
+            type={
+              status === DocumentReviewStatusEnum.ReviseNeeded
+                ? "disabled"
+                : "default"
+            }
             style={
-              status === "수정 요청"
+              status === DocumentReviewStatusEnum.ReviseNeeded
                 ? {}
                 : {
                     border: `1px solid ${theme.colors.GREEN[600]}`,
@@ -115,11 +122,13 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
           </Button>
           <Button
             onClick={() => {
-              handleStatusChange("검토승인");
+              handleStatusChange(DocumentReviewStatusEnum.ReviewAccepted);
               onConfirm();
             }}
             type={
-              status === "승인" || status === "검토승인" || reviewText !== ""
+              status === DocumentReviewStatusEnum.Accepted ||
+              status === DocumentReviewStatusEnum.ReviewAccepted ||
+              reviewText !== ""
                 ? "disabled"
                 : "default"
             }

--- a/packages/web/src/features/documents/components/ReviewerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ReviewerExpenditureTable.tsx
@@ -31,10 +31,12 @@ import { useFormatter } from "next-intl";
 import DetailButton from "@sparcs-students/web/features/documents/components/_atomic/DetailButton";
 import DarkTag, {
   DarkTagColor,
+  isDarkTagColor,
 } from "@sparcs-students/web/common/components/Tag/DarkTag";
 import { budgetExpenseToString } from "@sparcs-students/web/features/documents/utils/enumToItem";
 import ExpenditureHelpButton from "@sparcs-students/web/features/documents/components/_atomic/ExpenditureHelpButton";
 import ReviewButton from "@sparcs-students/web/features/documents/components/_atomic/ReviewButton";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 // ExpenditureProps 인터페이스는 위에 정의된 대로 사용
 
@@ -48,7 +50,7 @@ export interface ExpenditureProps {
   thisYear: number;
   ratio: number | null;
   reason: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
   review: string;
 }
 
@@ -60,7 +62,10 @@ const columnHelper = createColumnHelper<ExpenditureProps>();
 
 const getColumns = (
   handleReviewChange: (code: number, newReview: string) => void,
-  handleStatusChange: (code: number, newStatus: string) => void,
+  handleStatusChange: (
+    code: number,
+    newStatus: DocumentReviewStatusEnum,
+  ) => void,
 ) => [
   columnHelper.accessor("code", {
     id: "code",
@@ -109,7 +114,11 @@ const getColumns = (
         info.getValue(),
         budgetClassExpenseTagList,
       );
-      return <DarkTag color={color}>{text}</DarkTag>;
+      return isDarkTagColor(color) ? (
+        <DarkTag color={color}>{text}</DarkTag>
+      ) : (
+        <LightTag color={color}>{text}</LightTag>
+      );
     },
     size: 180,
   }),
@@ -209,7 +218,10 @@ const ReviewerExpenditureTable: React.FC<ExpenditureTableProps> = ({
     );
   };
 
-  const handleStatusChange = (code: number, newStatus: string) => {
+  const handleStatusChange = (
+    code: number,
+    newStatus: DocumentReviewStatusEnum,
+  ) => {
     setData(prevData =>
       prevData.map(item =>
         item.code === code ? { ...item, status: newStatus } : item,

--- a/packages/web/src/features/documents/components/ViewerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ViewerExpenditureTable.tsx
@@ -32,9 +32,11 @@ import { useFormatter } from "next-intl";
 import DetailButton from "@sparcs-students/web/features/documents/components/_atomic/DetailButton";
 import DarkTag, {
   DarkTagColor,
+  isDarkTagColor,
 } from "@sparcs-students/web/common/components/Tag/DarkTag";
 import { budgetExpenseToString } from "@sparcs-students/web/features/documents/utils/enumToItem";
 import ExpenditureHelpButton from "@sparcs-students/web/features/documents/components/_atomic/ExpenditureHelpButton";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export interface ViewerExpenditureProps {
   code: number;
@@ -46,7 +48,7 @@ export interface ViewerExpenditureProps {
   thisYear: number;
   ratio: number | null;
   reason: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
 }
 
 interface ExpenditureTableProps {
@@ -103,7 +105,11 @@ const columns = [
         info.getValue(),
         budgetClassExpenseTagList,
       );
-      return <DarkTag color={color}>{text}</DarkTag>;
+      return isDarkTagColor(color) ? (
+        <DarkTag color={color}>{text}</DarkTag>
+      ) : (
+        <LightTag color={color}>{text}</LightTag>
+      );
     },
     size: 175,
   }),

--- a/packages/web/src/features/documents/components/_atomic/ReviewButton.tsx
+++ b/packages/web/src/features/documents/components/_atomic/ReviewButton.tsx
@@ -5,12 +5,13 @@ import Icon from "@sparcs-students/web/common/components/Icon";
 import ReviewModal, {
   ReadOnlyReviewModal,
 } from "@sparcs-students/web/features/documents/components/ReviewModal";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 type ReviewButtonProps = {
   review: string;
-  status: string;
+  status: DocumentReviewStatusEnum;
   handleReviewChange: (detail: string) => void;
-  handleStatusChange: (status: string) => void;
+  handleStatusChange: (status: DocumentReviewStatusEnum) => void;
 };
 
 type ReadOnlyReviewButtonProps = {

--- a/packages/web/src/features/documents/utils/tableTagList.ts
+++ b/packages/web/src/features/documents/utils/tableTagList.ts
@@ -8,6 +8,7 @@ import {
   DarkStatusDetail,
   StatusDetail,
 } from "@sparcs-students/web/utils/getTagDetail";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export const budgetDomainTagList: {
   // 구분
@@ -100,10 +101,14 @@ export const budgetDivisionExpenseTagList: {
     text: "비정기사업비",
     color: "LEMON",
   },
+  [BudgetDivisionExpenseEnum.Undefined]: {
+    text: "-",
+    color: "GRAY",
+  },
 };
 
 export const budgetClassExpenseTagList: {
-  [key in BudgetClassExpenseEnum]: DarkStatusDetail;
+  [key in BudgetClassExpenseEnum]: DarkStatusDetail | StatusDetail;
 } = {
   [BudgetClassExpenseEnum.Product]: {
     text: "상품비",
@@ -169,6 +174,10 @@ export const budgetClassExpenseTagList: {
     text: "격려금",
     color: "MAROON",
   },
+  [BudgetClassExpenseEnum.Undefined]: {
+    text: "-",
+    color: "GRAY",
+  },
 };
 
 export const getbudgetTypeTag = (type: string) => {
@@ -197,28 +206,30 @@ export const getbudgetRatioTag = (ratio: number | null) => {
   return { color: "GRAY", text: `-` };
 };
 
-export const getbudgetStatusTag = (type: string) => {
-  switch (type) {
-    case "승인":
-      return { color: "BLUE", text: type };
-    case "반려":
-      return { color: "RED700", text: type };
-    case "사후승인":
-      return { color: "TEAL", text: type };
-    case "검토승인":
-      return { color: "CYAN", text: type };
-    case "검토반려":
-      return { color: "RED500", text: type };
-    case "추가경정":
-      return { color: "CYAN", text: type };
-    case "검토중":
-      return { color: "MELON", text: type };
-    case "수정 요청":
-      return { color: "LEMON", text: type };
-    case "임시저장":
-      return { color: "ORCHID", text: type };
-    case "미저장":
-      return { color: "YELLOW", text: type };
+export const getbudgetStatusTag = (type: DocumentReviewStatusEnum) => {
+  switch (
+    type // TODO: enum
+  ) {
+    case DocumentReviewStatusEnum.Accepted:
+      return { color: "BLUE", text: "승인" };
+    case DocumentReviewStatusEnum.Rejected:
+      return { color: "RED700", text: "반려" };
+    case DocumentReviewStatusEnum.LateAccepted:
+      return { color: "TEAL", text: "사후승인" };
+    case DocumentReviewStatusEnum.ReviewAccepted:
+      return { color: "CYAN", text: "검토승인" };
+    case DocumentReviewStatusEnum.ReviewRejected:
+      return { color: "RED500", text: "검토반려" };
+    case DocumentReviewStatusEnum.Revised:
+      return { color: "CYAN", text: "추가경정" };
+    case DocumentReviewStatusEnum.Progress:
+      return { color: "MELON", text: "검토중" };
+    case DocumentReviewStatusEnum.ReviseNeeded:
+      return { color: "LEMON", text: "수정요청" };
+    case DocumentReviewStatusEnum.Draft:
+      return { color: "ORCHID", text: "임시저장" };
+    case DocumentReviewStatusEnum.Unsaved:
+      return { color: "YELLOW", text: "미저장" };
     default:
       return { color: "GRAY", text: type };
   }

--- a/packages/web/src/features/project/components/ReviewOperationPlan.tsx
+++ b/packages/web/src/features/project/components/ReviewOperationPlan.tsx
@@ -5,6 +5,7 @@ import Typography from "@sparcs-students/web/common/components/Typography";
 import styled, { useTheme } from "styled-components";
 import TextAreaInput from "@sparcs-students/web/common/components/Forms/TextAreaInput";
 import Button from "@sparcs-students/web/common/components/Buttons/Button";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 interface ReviewOperationPlanProps {
   review?: string;
@@ -23,7 +24,9 @@ const ReviewOperationPlan: React.FC<ReviewOperationPlanProps> = ({
 }) => {
   const theme = useTheme();
   const [reviewText, setReviewText] = useState(review);
-  const [status, setStatus] = useState<string>("");
+  const [status, setStatus] = useState<DocumentReviewStatusEnum>(
+    DocumentReviewStatusEnum.Progress,
+  );
 
   return (
     <FlexWrapper direction="column" gap={16}>
@@ -40,13 +43,17 @@ const ReviewOperationPlan: React.FC<ReviewOperationPlanProps> = ({
         <Button
           onClick={() => {
             reviewHandler(reviewText);
-            setStatus("검토반려");
+            setStatus(DocumentReviewStatusEnum.ReviewRejected);
           }}
           type={
-            status === "반려" || status === "검토반려" ? "disabled" : "default"
+            status === DocumentReviewStatusEnum.Rejected ||
+            status === DocumentReviewStatusEnum.ReviewRejected
+              ? "disabled"
+              : "default"
           }
           style={
-            status === "반려" || status === "검토반려"
+            status === DocumentReviewStatusEnum.Rejected ||
+            status === DocumentReviewStatusEnum.ReviewRejected
               ? {
                   width: "fit-content",
                   height: "36px",
@@ -69,11 +76,15 @@ const ReviewOperationPlan: React.FC<ReviewOperationPlanProps> = ({
         <Button
           onClick={() => {
             reviewHandler(reviewText);
-            setStatus("수정 요청");
+            setStatus(DocumentReviewStatusEnum.ReviseNeeded);
           }}
-          type={status === "수정 요청" ? "disabled" : "default"}
+          type={
+            status === DocumentReviewStatusEnum.ReviseNeeded
+              ? "disabled"
+              : "default"
+          }
           style={
-            status === "수정 요청"
+            status === DocumentReviewStatusEnum.ReviseNeeded
               ? {
                   width: "fit-content",
                   height: "36px",
@@ -96,10 +107,12 @@ const ReviewOperationPlan: React.FC<ReviewOperationPlanProps> = ({
         <Button
           onClick={() => {
             reviewHandler(reviewText);
-            setStatus("검토승인");
+            setStatus(DocumentReviewStatusEnum.ReviewAccepted);
           }}
           type={
-            status === "승인" || status === "검토승인" || reviewText !== ""
+            status === DocumentReviewStatusEnum.Accepted ||
+            status === DocumentReviewStatusEnum.ReviewAccepted ||
+            reviewText !== ""
               ? "disabled"
               : "default"
           }

--- a/packages/web/src/features/project/components/ReviewerProjectProposalTable.tsx
+++ b/packages/web/src/features/project/components/ReviewerProjectProposalTable.tsx
@@ -17,12 +17,13 @@ import DarkTag, {
 } from "@sparcs-students/web/common/components/Tag/DarkTag";
 import { useRouter } from "next/navigation";
 import ReviewButton from "@sparcs-students/web/features/documents/components/_atomic/ReviewButton";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export interface ProjectProposalProps {
   id: string;
   name: string;
   projectPeriod: string;
-  status: string; // TODO: enum으로 변경
+  status: DocumentReviewStatusEnum;
   review: string;
 }
 
@@ -35,7 +36,7 @@ const columnHelper = createColumnHelper<ProjectProposalProps>();
 
 const getColumns = (
   handleReviewChange: (id: string, newReview: string) => void,
-  handleStatusChange: (id: string, newStatus: string) => void,
+  handleStatusChange: (id: string, newStatus: DocumentReviewStatusEnum) => void,
 ) => [
   columnHelper.accessor("id", {
     id: "id",
@@ -106,7 +107,10 @@ const ReviewerProjectProposalTable: React.FC<
     );
   };
 
-  const handleStatusChange = (id: string, newStatus: string) => {
+  const handleStatusChange = (
+    id: string,
+    newStatus: DocumentReviewStatusEnum,
+  ) => {
     setData(prevData =>
       prevData.map(item =>
         item.id === id ? { ...item, status: newStatus } : item,

--- a/packages/web/src/features/project/components/ViewerProjectProposalTable.tsx
+++ b/packages/web/src/features/project/components/ViewerProjectProposalTable.tsx
@@ -16,12 +16,13 @@ import DarkTag, {
   DarkTagColor,
 } from "@sparcs-students/web/common/components/Tag/DarkTag";
 import { useRouter } from "next/navigation";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export interface ViewerProjectProposalProps {
   id: string;
   name: string;
   projectPeriod: string;
-  status: string; // TODO: enum으로 변경
+  status: DocumentReviewStatusEnum;
 }
 
 interface ProjectProposalTableProps {

--- a/packages/web/src/features/project/services/_mock/mockProjectProposalData.ts
+++ b/packages/web/src/features/project/services/_mock/mockProjectProposalData.ts
@@ -3,27 +3,28 @@ import { MemberProps } from "@sparcs-students/web/features/project/components/Me
 import { OperationPlanProps } from "@sparcs-students/web/features/project/components/OperationPlan";
 import { GroupProps } from "@sparcs-students/web/features/project/components/_atomic/GroupDetail";
 import { ProjectProposalProps } from "@sparcs-students/web/features/project/components/ReviewerProjectProposalTable";
+import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export const mockProjectProposalData: ProjectProposalProps[] = [
   {
     id: "1",
     name: "집행위원회 운영",
     projectPeriod: "2024.09.06 - 2024.12.06",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "",
   },
   {
     id: "2",
     name: "기업체 탐방",
     projectPeriod: "2024.09.06 - 2024.12.06",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "ㅁㄴㅇㄹ",
   },
   {
     id: "3",
     name: "연구실 탐방",
     projectPeriod: "2024.09.06 - 2024.12.06",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
     review: "ㅁㄴㅇㄹ",
   },
 ];
@@ -33,19 +34,19 @@ export const mockViewerProjectProposalData: ViewerProjectProposalProps[] = [
     id: "1",
     name: "집행위원회 운영",
     projectPeriod: "2024.09.06 - 2024.12.06",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
   },
   {
     id: "2",
     name: "기업체 탐방",
     projectPeriod: "2024.09.06 - 2024.12.06",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
   },
   {
     id: "3",
     name: "연구실 탐방",
     projectPeriod: "2024.09.06 - 2024.12.06",
-    status: "승인",
+    status: DocumentReviewStatusEnum.Accepted,
   },
 ];
 

--- a/packages/web/src/utils/getTagDetail.ts
+++ b/packages/web/src/utils/getTagDetail.ts
@@ -21,10 +21,9 @@ const getTagDetail = <T extends number>(
 const getDarkTagDetail = <T extends number>(
   status: T,
   enumDictionary: {
-    [key in T]: DarkStatusDetail;
+    [key in T]: DarkStatusDetail | StatusDetail;
   },
-): DarkStatusDetail =>
-  enumDictionary[status] || { text: "None", color: "GRAY" };
+) => enumDictionary[status] || { text: "None", color: "GRAY" };
 
 export { getTagDetail, getDarkTagDetail };
 export type { StatusDetail, DarkStatusDetail };


### PR DESCRIPTION
# 요약 \*
It closes #111

매니저 페이지에 쓰일 수입 테이블, 지출 테이블을 모두 구현 완료 했습니다!

- 검토 상태를 나타내는 `DocumentReviewStatusEnum` 만듦, 레포 내 모든 코드에 적용 완료
- 수입, 지출 테이블은 react hook form을 사용하여 만들었습니다. submit 버튼 활성화해서 누르시고 콘솔 창 체크해 보시면 어떤 식으로 데이터 나오는지 보실 수 있습니다! 각 테이블의 로직은 아래 영상을 참고해 주세요!
    - 참고로 지출 테이블은 격려금이 디폴트로 떠 있다고 합니다.
    -` isProposal 값을 boolean`으로 넣어주면 예/결산에 모두 사용 가능합니다.

각 테이블에 들어가는 데이터 속성은 3/19 회의록에 노션 페이지 하나 파서 적어 놓았습니다

# 스크린샷
https://github.com/user-attachments/assets/9c7a3a90-3438-480d-9f41-b4c326c91399

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 매니저 페이지 만들기
- 
