### PR TITLE
Connect Nav and Add NotImplementedPage

### DIFF
--- a/packages/web/src/app/activity-certificate/page.tsx
+++ b/packages/web/src/app/activity-certificate/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const ActivityCertificate = () => <NotImplementedComponent />;
+
+export default ActivityCertificate;

--- a/packages/web/src/app/affiliation/page.tsx
+++ b/packages/web/src/app/affiliation/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Affiliation = () => <NotImplementedComponent />;
+
+export default Affiliation;

--- a/packages/web/src/app/agendas/page.tsx
+++ b/packages/web/src/app/agendas/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Agendas = () => <NotImplementedComponent />;
+
+export default Agendas;

--- a/packages/web/src/app/central-executive-committee/page.tsx
+++ b/packages/web/src/app/central-executive-committee/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const CentralExecutiveCommittee = () => <NotImplementedComponent />;
+
+export default CentralExecutiveCommittee;

--- a/packages/web/src/app/forms/page.tsx
+++ b/packages/web/src/app/forms/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Forms = () => <NotImplementedComponent />;
+
+export default Forms;

--- a/packages/web/src/app/info/page.tsx
+++ b/packages/web/src/app/info/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Info = () => <NotImplementedComponent />;
+
+export default Info;

--- a/packages/web/src/app/meetings/page.tsx
+++ b/packages/web/src/app/meetings/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Meetings = () => <NotImplementedComponent />;
+
+export default Meetings;

--- a/packages/web/src/app/notice/page.tsx
+++ b/packages/web/src/app/notice/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Notice = () => <NotImplementedComponent />;
+
+export default Notice;

--- a/packages/web/src/app/petition/page.tsx
+++ b/packages/web/src/app/petition/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Petition = () => <NotImplementedComponent />;
+
+export default Petition;

--- a/packages/web/src/app/rules/page.tsx
+++ b/packages/web/src/app/rules/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import NotImplementedComponent from "@sparcs-students/web/features/NotImplemented/NotImplementedComponent";
+
+const Rules = () => <NotImplementedComponent />;
+
+export default Rules;

--- a/packages/web/src/constants/nav.ts
+++ b/packages/web/src/constants/nav.ts
@@ -1,11 +1,12 @@
 import type { Paths } from "./paths";
 
 const headerPaths: (keyof Paths)[] = [
-  "STUDENTS0",
-  "STUDENTS1",
-  "STUDENTS2",
-  "STUDENTS3",
-  "STUDENTS4",
+  "STUDENTS",
+  "NOTICE",
+  "COMMITTEE",
+  "DOCUMENTS",
+  "ACTIVITY_CERTIFICATE",
+  "PETITION",
 ];
 const footerPaths: (keyof Paths)[] = ["MADE_BY", "LICENSE", "TERMS_OF_SERVICE"];
 

--- a/packages/web/src/constants/paths.ts
+++ b/packages/web/src/constants/paths.ts
@@ -6,51 +6,61 @@
 
 const paths = {
   HOME: { name: "홈", path: "/" },
-  STUDENTS0: {
-    name: "총학 소개",
+  STUDENTS: {
+    name: "총학생회",
     sub: [
       {
-        name: "총학 소개",
-        path: "/students",
+        name: "소개",
+        path: "/info",
+      },
+      {
+        name: "중앙집행위원회",
+        path: "/central-executive-committee",
+      },
+      {
+        name: "서식",
+        path: "/forms",
+      },
+      {
+        name: "제휴",
+        path: "/affiliation",
       },
     ],
   },
-  STUDENTS1: {
+  NOTICE: {
     name: "공지사항",
-    sub: [
-      {
-        name: "공지사항",
-        path: "/",
-      },
-    ],
+    path: "/notice",
   },
-  STUDENTS2: {
-    name: "회칙",
+  COMMITTEE: {
+    name: "의결기구",
     sub: [
       {
         name: "회칙",
-        path: "/",
+        path: "/rules",
       },
-    ],
-  },
-  STUDENTS3: {
-    name: "안건지/회의록",
-    sub: [
       {
-        name: "안건지/회의록",
-        path: "/",
+        name: "안건지",
+        path: "/agendas",
       },
-    ],
-  },
-  STUDENTS4: {
-    name: "예/결산",
-    sub: [
       {
-        name: "예/결산",
-        path: "/",
+        name: "회의록",
+        path: "/meetings",
       },
     ],
   },
+  DOCUMENTS: {
+    name: "예·결산 조회",
+    path: "/document-lookup",
+  },
+  ACTIVITY_CERTIFICATE: {
+    name: "활동인증서",
+    path: "/activity-certificate",
+  },
+  PETITION: {
+    name: "학생 청원",
+    path: "/petition",
+  },
+
   MADE_BY: { name: "만든 사람들", path: "/credits" },
   LICENSE: { name: "라이센스", path: "/" },
   TERMS_OF_SERVICE: { name: "이용 약관", path: "/" },

--- a/packages/web/src/features/NotImplemented/NotImplementedComponent.tsx
+++ b/packages/web/src/features/NotImplemented/NotImplementedComponent.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import React from "react";
+
+const NotImplementedComponent: React.FC = () => (
+  <div>
+    <h3>아직 구현되지 않았어요!</h3>
+  </div>
+);
+
+export default NotImplementedComponent;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #135
<h2>봐줬으면 좋겠는 것</h2>

- 제가 봤을 때 비슷한 기능들끼리 묶은 건데 그룹이 적절한지 봐주세요!
    - 중앙집행위원회 페이지는 공약이행상황판이 필요하대서 그거 넣으려고 만든 거에요 (중집 공약이행상황판은 너무 길어서 그냥 중집이라고 했어요)
    - 이외.. 등등등..

<h3>내용 요약</h3>

- 제안서에 나와있는 걸 기준으로 기능 정리해서 Nav 만들고, 구현 안 된 페이지들 모두 틀만 짜 두었습니다. 아래와 같은 이유로
    - 프론트 분들 페이지 구현하실 때 url 틀이 미리 있으면 좋겠다는 생각
    - 어떤 기능이 구현이 안 되었는지 감이 잘 안 오는데, nav에 떠 있으면 비교적 잘 보임

- 예결산 쪽은 페이지 작업 중인 곳이라 건들지 않았어요 머지되면 딱 연결 잘 될 듯 하하하

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="1512" alt="스크린샷 2025-03-19 오후 3 55 45" src="https://github.com/user-attachments/assets/3fc55a5f-01ef-49ed-ba8e-0bab7fe6178b" />



# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
