### PR TITLE
Fix reviewer modal placeholder

### DIFF
--- a/packages/web/src/features/documents/components/ReviewModal.tsx
+++ b/packages/web/src/features/documents/components/ReviewModal.tsx
@@ -63,7 +63,7 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
         검토 내용에 대한 설명
       </Typography>
       <TextAreaInput
-        placeholder={review === "" ? "내용을 입력하세요." : review}
+        placeholder="내용을 입력하세요."
         handleChange={setReviewText}
         value={reviewText}
       />


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #143 

일단 현상의 원인은 과거의 제가 그렇게 코드를 짜놨기 때문입니다,, 아마 의도는 내용을 지워도 이전에 내가 뭐라고 적었는지를 볼 수 있으면 편하지 않을까 하는 자의적인 추측(?)이었던 것 같아요! 해당 부분 없애고 고정 placeholder 넣어서 해결했습니다~~

취소 버튼은 #134 머지되면 알아서 고쳐질거에요~

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/6598e6ad-dc4a-45a1-b253-1ef6affe61da)


# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
