### PR TITLE
Impl Manager BudgetProposal, make BudgetProposal Clean

### DIFF
--- a/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
@@ -1,35 +1,12 @@
 "use client";
 
 import React, { useState } from "react";
-// import { useParams } from "next/navigation";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
 import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import ViewResult from "@sparcs-students/web/features/documents/components/ViewResult";
-import {
-  // ViewerIncomeTable,
-  ViewerIncomeProps,
-} from "@sparcs-students/web/features/budget/components/ViewerIncomeTable";
-import {
-  // ViewerExpenditureTable,
-  ViewerExpenditureProps,
-} from "@sparcs-students/web/features/documents/components/ViewerExpenditureTable";
-import TotalTable, {
-  TotalProps,
-} from "@sparcs-students/web/features/documents/components/TotalTable";
-import {
-  // mockExpenditureData,
-  // mockManagerExpenditureData,
-  // mockManagerIncomeData,
-  // mockManagerProjectNameCandidateList,
-  mockExpenditureData,
-  // mockManagerIncomeData,
-  // mockIncomeData,
-  // mockIncomeManagerData,
-  mockViewerExpenditureData,
-  mockViewerIncomeData,
-  mockViewResultData,
-} from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+
+import { mockViewResultData } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
 import PageTitle from "@sparcs-students/web/common/components/PageTitle";
 import { DocumentType } from "@sparcs-students/web/common/components/SelectCard/DocumentTypeSelectCard";
 import { mockData } from "@sparcs-students/web/features/documents/components/ThreeInput/mock";
@@ -37,167 +14,69 @@ import ThreeInput, {
   ThreeInputItem,
 } from "@sparcs-students/web/features/documents/components/ThreeInput";
 
-// import ManagerIncomeTable from "@sparcs-students/web/features/budget/components/ManagerIncomeTable";
-import ReviewerExpenditureTable from "@sparcs-students/web/features/documents/components/ReviewerExpenditureTable";
-import styled from "styled-components";
-import { overlay } from "overlay-kit";
-import Modal from "@sparcs-students/web/common/components/Modal";
-import ConfirmModalContent from "@sparcs-students/web/common/components/Modal/ConfirmModalContent";
-import CancellableModalContent from "@sparcs-students/web/common/components/Modal/CancellableModalContent";
-import { BudgetDomainEnum } from "@sparcs-students/interface/common/enum/budget.enum";
 import BreadCrumb from "@sparcs-students/web/common/components/BreadCrumb";
-// import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
-// import ManagerExpenditureTable from "@sparcs-students/web/features/documents/components/ManagerExpenditureTable";
-import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
+import { UserPermission } from "@sparcs-students/web/features/documents/constants/userPermission";
 
-interface DomainAccum {
-  incomeLastYear: number;
-  incomeThisYear: number;
-  expenditureLastYear: number;
-  expenditureThisYear: number;
-}
+// import ViewerBudgetProposalFrame from "@sparcs-students/web/features/budget/frames/ViewerBudgetProposalFrame";
+import ReviewerBudgetProposalFrame from "@sparcs-students/web/features/budget/frames/ReviewerBudgetProposalFrame";
+// import ManagerBudgetProposalFrame from "@sparcs-students/web/features/budget/frames/ManagerBudgetProposalFrame";
+import { useRouter, useSearchParams } from "next/navigation";
 
-const ButtonWrapper = styled.div`
-  gap: 30px;
-  flex-direction: row;
-  display: flex;
-  justify-content: center;
-`;
-
-const dataToTotal = (
-  incomeData: ViewerIncomeProps[],
-  expenditureData: ViewerExpenditureProps[],
-) => {
-  const incomeMap = incomeData.reduce<Record<BudgetDomainEnum, DomainAccum>>(
-    (acc, cur) => {
-      const { budgetDomain, lastYear, thisYear } = cur;
-
-      const prev = acc[budgetDomain] ?? {
-        incomeLastYear: 0,
-        incomeThisYear: 0,
-        expenditureLastYear: 0,
-        expenditureThisYear: 0,
-      };
-
-      return {
-        ...acc,
-        [budgetDomain]: {
-          ...prev,
-          incomeLastYear: prev.incomeLastYear + lastYear,
-          incomeThisYear: prev.incomeThisYear + thisYear,
-        },
-      };
-    },
-    {} as Record<BudgetDomainEnum, DomainAccum>,
-  );
-
-  const combinedMap = expenditureData.reduce<
-    Record<BudgetDomainEnum, DomainAccum>
-  >((acc, cur) => {
-    const { budgetDomain, lastYear, thisYear } = cur;
-
-    const prev = acc[budgetDomain] ?? {
-      incomeLastYear: 0,
-      incomeThisYear: 0,
-      expenditureLastYear: 0,
-      expenditureThisYear: 0,
-    };
-
-    return {
-      ...acc,
-      [budgetDomain]: {
-        ...prev,
-        expenditureLastYear: prev.expenditureLastYear + lastYear,
-        expenditureThisYear: prev.expenditureThisYear + thisYear,
-      },
-    };
-  }, incomeMap);
-
-  const resultArray = Object.entries(combinedMap).reduce<TotalProps[]>(
-    (acc, [key, sums]) => {
-      const domain = Number(key) as BudgetDomainEnum;
-
-      const incomeRow = {
-        budgetDomain: domain,
-        type: "수입",
-        lastYear: sums.incomeLastYear,
-        thisYear: sums.incomeThisYear,
-        ratio:
-          sums.incomeLastYear === 0
-            ? null
-            : (sums.incomeThisYear / sums.incomeLastYear) * 100,
-      };
-
-      const expenditureRow = {
-        budgetDomain: domain,
-        type: "지출",
-        lastYear: sums.expenditureLastYear,
-        thisYear: sums.expenditureThisYear,
-        ratio:
-          sums.expenditureLastYear === 0
-            ? null
-            : (sums.expenditureThisYear / sums.expenditureLastYear) * 100,
-      };
-
-      const totalLastYear = sums.incomeLastYear - sums.expenditureLastYear;
-      const totalThisYear = sums.incomeThisYear - sums.expenditureThisYear;
-      const totalRow = {
-        budgetDomain: domain,
-        type: "총계",
-        lastYear: totalLastYear,
-        thisYear: totalThisYear,
-        ratio:
-          totalLastYear === 0 ? null : (totalThisYear / totalLastYear) * 100,
-      };
-
-      return [...acc, incomeRow, expenditureRow, totalRow];
-    },
-    [] as {
-      budgetDomain: BudgetDomainEnum;
-      type: string;
-      lastYear: number;
-      thisYear: number;
-      ratio: number;
-    }[],
-  );
-
-  return resultArray;
-};
-
-const Proposal = () => {
-  // const { id } = useParams();
+const BudgetProposal = () => {
   const items: ThreeInputItem[] = mockData;
+  const searchParams = useSearchParams();
+  const queryYear = parseInt(searchParams.get("year") || "") || items[0].year;
+  const queryIsSpring = searchParams.get("isSpring") === "true";
+  const queryType = searchParams.get("type") as DocumentType | null;
+  const queryKey = searchParams.get("key");
+  const queryValue = searchParams.get("value");
+  const queryId = parseInt(searchParams.get("id") || "");
+  console.log(
+    queryYear,
+    queryIsSpring,
+    queryType,
+    queryKey,
+    queryValue,
+    queryId,
+  );
+
   const [date, setDate] = useState(mockViewResultData.submitDate);
-  const [year, setYear] = useState<number>(items[0].year);
-  const [isSpring, setIsSpring] = useState<boolean | null>(null);
-  const [type, setType] = useState<DocumentType | null>(null);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null); // TODO: enum으로 변경
-  const [selectedValue, setSelectedValue] = useState<string | null>(null); // TODO: enum으로 변경
-  const userPermission = 2; // 1: viewer, 2: reviewer, 3: manager TODO: 실제 권한으로 변경
+  const [year, setYear] = useState<number>(queryYear);
+  const [isSpring, setIsSpring] = useState<boolean | null>(queryIsSpring);
+  const [type, setType] = useState<DocumentType | null>(queryType);
+  const [selectedKey, setSelectedKey] = useState<string | null>(queryKey); // TODO: enum으로 변경
+  const [selectedValue, setSelectedValue] = useState<string | null>(queryValue); // TODO: enum으로 변경
+  const [selectedId, setSelectedId] = useState<number | null>(queryId);
+  const userPermission = UserPermission.Reviewer; // 1: viewer, 2: reviewer, 3: manager TODO: 실제 권한으로 변경
 
-  const openSaveModal = () => {
-    // TODO: add save logic
-    overlay.open(({ isOpen, close }) => (
-      <Modal isOpen={isOpen} width="400px">
-        <ConfirmModalContent onConfirm={() => close()}>
-          저장되었습니다.
-        </ConfirmModalContent>
-      </Modal>
-    ));
-  };
+  const router = useRouter();
 
-  const openDiscardModal = () => {
-    // TODO: add discard logic
-    overlay.open(({ isOpen, close }) => (
-      <Modal isOpen={isOpen} width="400px">
-        <CancellableModalContent
-          onConfirm={() => close()}
-          onClose={() => close()}
-        >
-          임시저장 내역을{"\n"}모두 삭제하시겠습니까?
-        </CancellableModalContent>
-      </Modal>
-    ));
+  const lookUp = (id: number) => {
+    const query = new URLSearchParams({
+      year: String(year),
+      isSpring: String(isSpring),
+      type: String(type),
+      key: selectedKey ?? "",
+      value: selectedValue ?? "",
+      id: String(id),
+    }).toString();
+
+    switch (type) {
+      case "사업 계획서":
+        router.push(`/document-lookup/project-proposal/result/${id}?${query}`);
+        break;
+      case "사업 보고서":
+        router.push(`/document-lookup/project-report/result/${id}?${query}`);
+        break;
+      case "예산안":
+        router.push(`/document-lookup/budget-proposal/result/${id}?${query}`);
+        break;
+      case "결산안":
+        router.push(`/document-lookup/budget-report/result/${id}?${query}`);
+        break;
+      default:
+        throw new Error(`잘못된 문서 유형: ${type}`);
+    }
   };
 
   return (
@@ -229,10 +108,15 @@ const Proposal = () => {
               setSelectedKey={setSelectedKey}
               selectedValue={selectedValue}
               setSelectedValue={setSelectedValue}
+              setSelectedId={setSelectedId}
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
-            <Button buttonText="조회" style={{ marginLeft: "auto" }} />
+            <Button
+              buttonText="조회"
+              style={{ marginLeft: "auto" }}
+              onClick={() => lookUp(selectedId as number)}
+            />
           </FlexWrapper>
         </FlexWrapper>
         <ViewResult
@@ -240,47 +124,17 @@ const Proposal = () => {
           submitDate={date}
           handleDateChange={setDate}
         />
-        {/* {userPermission === 1 && <ViewerIncomeTable data={mockViewerIncomeData} />} */}
-        {userPermission === 2 && (
-          <ReviewerIncomeTable initialData={mockViewerIncomeData} />
-        )}
-        {/* {userPermission === 3 && ( */}
-        {/*   <ManagerIncomeTable initialData={mockManagerIncomeData} isProposal /> */}
+        {/* {userPermission === UserPermission.Viewer && ( */}
+        {/*   <ViewerBudgetProposalFrame /> */}
         {/* )} */}
-
-        {/* {userPermission === 1 && <ViewerExpenditureTable data={mockViewerExpenditureData} type="proposal" pageId={id} />} */}
-        {userPermission === 2 && (
-          <ReviewerExpenditureTable initialData={mockExpenditureData} />
+        {userPermission === UserPermission.Reviewer && (
+          <ReviewerBudgetProposalFrame />
         )}
-        {/* {userPermission === 3 && ( */}
-        {/*   <ManagerExpenditureTable */}
-        {/*     initialData={mockManagerExpenditureData} */}
-        {/*     projectNameCandidate={mockManagerProjectNameCandidateList} */}
-        {/*     isProposal */}
-        {/*   /> */}
+        {/* {userPermission === UserPermission.Manager && ( */}
+        {/*   <ManagerBudgetProposalFrame /> */}
         {/* )} */}
-        <TotalTable
-          data={dataToTotal(mockViewerIncomeData, mockViewerExpenditureData)}
-        />
-        {userPermission === 2 && (
-          <ButtonWrapper>
-            <Button
-              type="reverse"
-              onClick={openDiscardModal}
-              style={{ width: "100px", padding: "8px 16px" }}
-            >
-              삭제
-            </Button>
-            <Button
-              onClick={openSaveModal}
-              style={{ width: "100px", padding: "8px 16px" }}
-            >
-              제출
-            </Button>
-          </ButtonWrapper>
-        )}
       </FlexWrapper>
     </FlexWrapper>
   );
 };
-export default Proposal;
+export default BudgetProposal;

--- a/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
@@ -31,14 +31,6 @@ const BudgetProposal = () => {
   const queryKey = searchParams.get("key");
   const queryValue = searchParams.get("value");
   const queryId = parseInt(searchParams.get("id") || "");
-  console.log(
-    queryYear,
-    queryIsSpring,
-    queryType,
-    queryKey,
-    queryValue,
-    queryId,
-  );
 
   const [date, setDate] = useState(mockViewResultData.submitDate);
   const [year, setYear] = useState<number>(queryYear);

--- a/packages/web/src/app/document-lookup/budget-report/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/budget-report/result/[id]/page.tsx
@@ -1,193 +1,72 @@
 "use client";
 
 import React, { useState } from "react";
-// import { useParams } from "next/navigation";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
 import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import ViewResult from "@sparcs-students/web/features/documents/components/ViewResult";
-// import ViewerIncomeTable, {
-//   ViewerIncomeProps,
-// } from "@sparcs-students/web/features/budget/components/ViewerIncomeTable";
-// import ViewerExpenditureTable, {
-//   ViewerExpenditureProps,
-// } from "@sparcs-students/web/features/documents/components/ViewerExpenditureTable";
-import TotalTable, {
-  TotalProps,
-} from "@sparcs-students/web/features/documents/components/TotalTable";
-import {
-  mockExpenditureData,
-  mockViewerExpenditureData,
-  mockViewerIncomeData,
-  mockViewResultData,
-} from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+import { mockViewResultData } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
 import PageTitle from "@sparcs-students/web/common/components/PageTitle";
 import { DocumentType } from "@sparcs-students/web/common/components/SelectCard/DocumentTypeSelectCard";
 import { mockData } from "@sparcs-students/web/features/documents/components/ThreeInput/mock";
 import ThreeInput, {
   ThreeInputItem,
 } from "@sparcs-students/web/features/documents/components/ThreeInput";
-import { BudgetDomainEnum } from "@sparcs-students/interface/common/enum/budget.enum";
-// import { useParams } from "next/navigation";
 import BreadCrumb from "@sparcs-students/web/common/components/BreadCrumb";
-import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
-import ReviewerExpenditureTable from "@sparcs-students/web/features/documents/components/ReviewerExpenditureTable";
-import { overlay } from "overlay-kit";
-import Modal from "@sparcs-students/web/common/components/Modal";
-import ConfirmModalContent from "@sparcs-students/web/common/components/Modal/ConfirmModalContent";
-import CancellableModalContent from "@sparcs-students/web/common/components/Modal/CancellableModalContent";
-import styled from "styled-components";
-import { ViewerExpenditureProps } from "@sparcs-students/web/features/documents/components/ViewerExpenditureTable";
-import { ViewerIncomeProps } from "@sparcs-students/web/features/budget/components/ViewerIncomeTable";
-
-interface DomainAccum {
-  incomeLastYear: number;
-  incomeThisYear: number;
-  expenditureLastYear: number;
-  expenditureThisYear: number;
-}
-
-const ButtonWrapper = styled.div`
-  gap: 30px;
-  flex-direction: row;
-  display: flex;
-  justify-content: center;
-`;
-
-const dataToTotal = (
-  incomeData: ViewerIncomeProps[],
-  expenditureData: ViewerExpenditureProps[],
-) => {
-  const incomeMap = incomeData.reduce<Record<BudgetDomainEnum, DomainAccum>>(
-    (acc, cur) => {
-      const { budgetDomain, lastYear, thisYear } = cur;
-
-      const prev = acc[budgetDomain] ?? {
-        incomeLastYear: 0,
-        incomeThisYear: 0,
-        expenditureLastYear: 0,
-        expenditureThisYear: 0,
-      };
-
-      return {
-        ...acc,
-        [budgetDomain]: {
-          ...prev,
-          incomeLastYear: prev.incomeLastYear + lastYear,
-          incomeThisYear: prev.incomeThisYear + thisYear,
-        },
-      };
-    },
-    {} as Record<BudgetDomainEnum, DomainAccum>,
-  );
-
-  const combinedMap = expenditureData.reduce<
-    Record<BudgetDomainEnum, DomainAccum>
-  >((acc, cur) => {
-    const { budgetDomain, lastYear, thisYear } = cur;
-
-    const prev = acc[budgetDomain] ?? {
-      incomeLastYear: 0,
-      incomeThisYear: 0,
-      expenditureLastYear: 0,
-      expenditureThisYear: 0,
-    };
-
-    return {
-      ...acc,
-      [budgetDomain]: {
-        ...prev,
-        expenditureLastYear: prev.expenditureLastYear + lastYear,
-        expenditureThisYear: prev.expenditureThisYear + thisYear,
-      },
-    };
-  }, incomeMap);
-
-  const resultArray = Object.entries(combinedMap).reduce<TotalProps[]>(
-    (acc, [key, sums]) => {
-      const domain = Number(key) as BudgetDomainEnum;
-
-      const incomeRow = {
-        budgetDomain: domain,
-        type: "수입",
-        lastYear: sums.incomeLastYear,
-        thisYear: sums.incomeThisYear,
-        ratio:
-          sums.incomeLastYear === 0
-            ? null
-            : (sums.incomeThisYear / sums.incomeLastYear) * 100,
-      };
-
-      const expenditureRow = {
-        budgetDomain: domain,
-        type: "지출",
-        lastYear: sums.expenditureLastYear,
-        thisYear: sums.expenditureThisYear,
-        ratio:
-          sums.expenditureLastYear === 0
-            ? null
-            : (sums.expenditureThisYear / sums.expenditureLastYear) * 100,
-      };
-
-      const totalLastYear = sums.incomeLastYear - sums.expenditureLastYear;
-      const totalThisYear = sums.incomeThisYear - sums.expenditureThisYear;
-      const totalRow = {
-        budgetDomain: domain,
-        type: "총계",
-        lastYear: totalLastYear,
-        thisYear: totalThisYear,
-        ratio:
-          totalLastYear === 0 ? null : (totalThisYear / totalLastYear) * 100,
-      };
-
-      return [...acc, incomeRow, expenditureRow, totalRow];
-    },
-    [] as {
-      budgetDomain: BudgetDomainEnum;
-      type: string;
-      lastYear: number;
-      thisYear: number;
-      ratio: number;
-    }[],
-  );
-
-  return resultArray;
-};
+import { UserPermission } from "@sparcs-students/web/features/documents/constants/userPermission";
+// import ManagerBudgetReportFrame from "@sparcs-students/web/features/budget/frames/ManagerBudgetReportFrame";
+import ReviewerBudgetReportFrame from "@sparcs-students/web/features/budget/frames/ReviewerBudgetReportFrame";
+// import ViewerBudgetReportFrame from "@sparcs-students/web/features/budget/frames/ViewerBudgetReportFrame";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const Report = () => {
   // const { id } = useParams();
   const items: ThreeInputItem[] = mockData;
+  const searchParams = useSearchParams();
+  const queryYear = parseInt(searchParams.get("year") || "") || items[0].year;
+  const queryIsSpring = searchParams.get("isSpring") === "true";
+  const queryType = searchParams.get("type") as DocumentType | null;
+  const queryKey = searchParams.get("key");
+  const queryValue = searchParams.get("value");
+  const queryId = parseInt(searchParams.get("id") || "");
+
   const [date, setDate] = useState(mockViewResultData.submitDate);
-  const [year, setYear] = useState<number>(items[0].year);
-  const [isSpring, setIsSpring] = useState<boolean | null>(null);
-  const [type, setType] = useState<DocumentType | null>(null);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null); // TODO: enum으로 변경
-  const [selectedValue, setSelectedValue] = useState<string | null>(null); // TODO: enum으로 변경
-  const userPermission = 2; // 1: viewer, 2: reviewer, 3: manager TODO: 실제 권한으로 변경
+  const [year, setYear] = useState<number>(queryYear);
+  const [isSpring, setIsSpring] = useState<boolean | null>(queryIsSpring);
+  const [type, setType] = useState<DocumentType | null>(queryType);
+  const [selectedKey, setSelectedKey] = useState<string | null>(queryKey); // TODO: enum으로 변경
+  const [selectedValue, setSelectedValue] = useState<string | null>(queryValue); // TODO: enum으로 변경
+  const [selectedId, setSelectedId] = useState<number | null>(queryId);
+  const userPermission = UserPermission.Reviewer; // 1: viewer, 2: reviewer, 3: manager TODO: 실제 권한으로 변경
 
-  const openSaveModal = () => {
-    // TODO: add save logic
-    overlay.open(({ isOpen, close }) => (
-      <Modal isOpen={isOpen} width="400px">
-        <ConfirmModalContent onConfirm={() => close()}>
-          저장되었습니다.
-        </ConfirmModalContent>
-      </Modal>
-    ));
-  };
+  const router = useRouter();
 
-  const openDiscardModal = () => {
-    // TODO: add discard logic
-    overlay.open(({ isOpen, close }) => (
-      <Modal isOpen={isOpen} width="400px">
-        <CancellableModalContent
-          onConfirm={() => close()}
-          onClose={() => close()}
-        >
-          임시저장 내역을{"\n"}모두 삭제하시겠습니까?
-        </CancellableModalContent>
-      </Modal>
-    ));
+  const lookUp = (id: number) => {
+    const query = new URLSearchParams({
+      year: String(year),
+      isSpring: String(isSpring),
+      type: String(type),
+      key: selectedKey ?? "",
+      value: selectedValue ?? "",
+      id: String(id),
+    }).toString();
+
+    switch (type) {
+      case "사업 계획서":
+        router.push(`/document-lookup/project-proposal/result/${id}?${query}`);
+        break;
+      case "사업 보고서":
+        router.push(`/document-lookup/project-report/result/${id}?${query}`);
+        break;
+      case "예산안":
+        router.push(`/document-lookup/budget-proposal/result/${id}?${query}`);
+        break;
+      case "결산안":
+        router.push(`/document-lookup/budget-report/result/${id}?${query}`);
+        break;
+      default:
+        throw new Error(`잘못된 문서 유형: ${type}`);
+    }
   };
 
   return (
@@ -220,10 +99,15 @@ const Report = () => {
               setSelectedKey={setSelectedKey}
               selectedValue={selectedValue}
               setSelectedValue={setSelectedValue}
+              setSelectedId={setSelectedId}
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
-            <Button buttonText="조회" style={{ marginLeft: "auto" }} />
+            <Button
+              buttonText="조회"
+              style={{ marginLeft: "auto" }}
+              onClick={() => lookUp(selectedId as number)}
+            />
           </FlexWrapper>
         </FlexWrapper>
         <ViewResult
@@ -231,41 +115,15 @@ const Report = () => {
           submitDate={date}
           handleDateChange={setDate}
         />
-        {/* {userPermission === 1 && <ViewerIncomeTable data={mockViewerIncomeData} />} */}
-        {userPermission === 2 && (
-          <ReviewerIncomeTable initialData={mockViewerIncomeData} />
+        {/* {userPermission === UserPermission.Viewer && ( */}
+        {/*   <ViewerBudgetReportFrame /> */}
+        {/* )} */}
+        {userPermission === UserPermission.Reviewer && (
+          <ReviewerBudgetReportFrame />
         )}
-        {/* {userPermission === 1 && */}
-        {/*   <ViewerExpenditureTable */}
-        {/*     data={mockViewerExpenditureData} */}
-        {/*     type="report" */}
-        {/*     pageId={id} */}
-        {/*   /> */}
-        {/* } */}
-        {userPermission === 2 && (
-          <ReviewerExpenditureTable initialData={mockExpenditureData} />
-        )}
-
-        <TotalTable
-          data={dataToTotal(mockViewerIncomeData, mockViewerExpenditureData)}
-        />
-        {userPermission === 2 && (
-          <ButtonWrapper>
-            <Button
-              type="reverse"
-              onClick={openDiscardModal}
-              style={{ width: "100px", padding: "8px 16px" }}
-            >
-              삭제
-            </Button>
-            <Button
-              onClick={openSaveModal}
-              style={{ width: "100px", padding: "8px 16px" }}
-            >
-              제출
-            </Button>
-          </ButtonWrapper>
-        )}
+        {/* {userPermission === UserPermission.Manager && ( */}
+        {/*   <ManagerBudgetReportFrame /> */}
+        {/* )} */}
       </FlexWrapper>
     </FlexWrapper>
   );

--- a/packages/web/src/app/document-lookup/page.tsx
+++ b/packages/web/src/app/document-lookup/page.tsx
@@ -21,27 +21,55 @@ const documentLookUp = () => {
   const [type, setType] = useState<DocumentType | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null); // TODO: enum으로 변경
   const [selectedValue, setSelectedValue] = useState<string | null>(null); // TODO: enum으로 변경
+  const [selectedId, setSelectedId] = useState<number | null>(null); // 단체마다 고유 id임
 
   const router = useRouter();
 
-  const lookUp = () => {
+  const lookUp = ({
+    id,
+    year: yearParam,
+    isSpring: isSpringParam,
+    type: typeParam,
+    key,
+    value,
+  }: {
+    id: number;
+    year: number;
+    isSpring: boolean;
+    type: DocumentType;
+    key: string;
+    value: string;
+  }) => {
     // TODO: api 연결하면 URL의 id값 적절하게 수정
+    // TODO: 여기서 id는 어떤 반기, 어떤 단체의 고유한 id
+    const query = new URLSearchParams({
+      id: id.toString(),
+      year: yearParam.toString(),
+      isSpring: isSpringParam.toString(),
+      type: typeParam,
+      key,
+      value,
+    });
+    let path = "";
+
     switch (type) {
       case "사업 계획서":
-        router.push("/document-lookup/project-proposal/result/1");
+        path = `/document-lookup/project-proposal/result/${id}`;
         break;
       case "사업 보고서":
-        router.push("/document-lookup/project-report/result/1");
+        path = `/document-lookup/project-report/result/${id}`;
         break;
       case "예산안":
-        router.push("/document-lookup/budget-proposal/result/1");
+        path = `/document-lookup/budget-proposal/result/${id}`;
         break;
       case "결산안":
-        router.push("/document-lookup/budget-report/result/1");
+        path = `/document-lookup/budget-report/result/${id}`;
         break;
-      default: // 있으면 안 되는 오류 케이스
+      default:
         throw new Error(`잘못된 문서 유형: ${type}`);
     }
+
+    router.push(`${path}?${query.toString()}`);
   };
 
   return (
@@ -70,13 +98,32 @@ const documentLookUp = () => {
               setSelectedKey={setSelectedKey}
               selectedValue={selectedValue}
               setSelectedValue={setSelectedValue}
+              setSelectedId={setSelectedId}
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
             <Button
               buttonText="조회"
               style={{ marginLeft: "auto" }}
-              onClick={lookUp}
+              onClick={() => {
+                if (
+                  selectedId != null &&
+                  year != null &&
+                  isSpring != null &&
+                  type != null &&
+                  selectedKey != null &&
+                  selectedValue != null
+                ) {
+                  lookUp({
+                    id: selectedId,
+                    year,
+                    isSpring,
+                    type,
+                    key: selectedKey,
+                    value: selectedValue,
+                  });
+                }
+              }}
             />
           </FlexWrapper>
         </FlexWrapper>

--- a/packages/web/src/common/components/Buttons/Button.tsx
+++ b/packages/web/src/common/components/Buttons/Button.tsx
@@ -19,6 +19,7 @@ type ButtonProps = {
   children?: React.ReactNode;
   iconType?: string;
   buttonText?: string;
+  onClick?: (() => void) | ((e: React.MouseEvent<HTMLDivElement>) => void);
 } & HTMLAttributes<HTMLDivElement>;
 
 const ButtonInner = styled.div`
@@ -110,6 +111,7 @@ const Button = ({
   children = undefined,
   iconType = "",
   buttonText = "",
+
   ...divProps
 }: ButtonProps) => {
   const ButtonChosenInner = ButtonTypeInner[type];

--- a/packages/web/src/common/components/Forms/TableTextInput.tsx
+++ b/packages/web/src/common/components/Forms/TableTextInput.tsx
@@ -35,6 +35,7 @@ const InputWrapper = styled.div`
   flex-direction: column;
   display: flex;
   gap: 4px;
+  flex: 1;
 `;
 
 const InputContainer = styled.div`
@@ -70,6 +71,7 @@ const Input = styled.input
   font-size: 14px;
   line-height: 14px;
   border: none;
+    text-align: center;
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
   color: ${({ theme }) => theme.colors.BLACK};
   background-color: ${({ theme }) => theme.colors.WHITE};
@@ -123,6 +125,7 @@ const TableTextInput: React.FC<TextInputProps> = ({
           hasPrefix={!!prefix}
           value={prefix ? value.toString().replace(prefix, "") : value}
           onChange={handleValueChange}
+          style={{ flex: 1, width: "100%" }}
           {...props}
         />
         {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}

--- a/packages/web/src/common/components/HoverClickText.tsx
+++ b/packages/web/src/common/components/HoverClickText.tsx
@@ -11,8 +11,14 @@ const StyledText = styled(Typography)`
   }
 `;
 
-const HoverClickText = ({ text = "" }: { text: string }) => (
-  <StyledText>{text}</StyledText>
-);
+interface HoverClickTextProps {
+  text: string;
+  onClick?: () => void;
+}
+
+const HoverClickText = ({
+  text = "",
+  onClick = () => {},
+}: HoverClickTextProps) => <StyledText onClick={onClick}>{text}</StyledText>;
 
 export default HoverClickText;

--- a/packages/web/src/common/components/InputSelect/index.tsx
+++ b/packages/web/src/common/components/InputSelect/index.tsx
@@ -58,6 +58,7 @@ const StyledSelect = styled.div.withConfig({
   align-items: center;
   gap: 10px;
   width: 100%;
+  flex: 1;
   outline: none;
   cursor: pointer;
   background-color: ${({ theme }) => theme.colors.WHITE};
@@ -98,6 +99,7 @@ const SelectWrapper = styled.div`
   width: 100%;
   flex-direction: column;
   display: flex;
+  flex: 1;
 `;
 
 const Select = ({

--- a/packages/web/src/common/components/Select/index.tsx
+++ b/packages/web/src/common/components/Select/index.tsx
@@ -15,6 +15,7 @@ export interface SelectItem<T> {
   label: string;
   value: T;
   selectable?: boolean;
+  id?: number;
 }
 
 interface SelectProps<T> {

--- a/packages/web/src/common/components/SelectCard/OrganizationSelectCard.tsx
+++ b/packages/web/src/common/components/SelectCard/OrganizationSelectCard.tsx
@@ -22,6 +22,7 @@ interface OrganizationSelectCardProps {
   setSelectedKey: (value: string) => void;
   selectedValue: string;
   setSelectedValue: (value: string) => void;
+  setSelectedId: (value: number | null) => void;
   disabled?: boolean;
 }
 
@@ -96,6 +97,7 @@ const OrganizationSelectCard: React.FC<OrganizationSelectCardProps> = ({
   setSelectedKey,
   selectedValue,
   setSelectedValue,
+  setSelectedId,
   disabled = false,
 }) => {
   const valueList = useMemo(() => {
@@ -109,8 +111,25 @@ const OrganizationSelectCard: React.FC<OrganizationSelectCardProps> = ({
     const selectedItem = totalList.find(item => item.key.value === newKey);
     if (selectedItem && selectedItem.values.length > 0) {
       setSelectedValue(selectedItem.values[0].value);
+      setSelectedId(selectedItem.values[0].id as number);
     } else {
       setSelectedValue("");
+      setSelectedId(null);
+    }
+  };
+
+  const handleValueChange = (newValue: string) => {
+    setSelectedValue(newValue);
+
+    const selectedItem = totalList.find(item => item.key.value === selectedKey);
+    const selectedValueItem = selectedItem?.values.find(
+      val => val.value === newValue,
+    );
+
+    if (selectedValueItem) {
+      setSelectedId(selectedValueItem.id as number);
+    } else {
+      setSelectedId(null);
     }
   };
 
@@ -149,7 +168,7 @@ const OrganizationSelectCard: React.FC<OrganizationSelectCardProps> = ({
             <Select
               items={valueList}
               value={selectedValue}
-              onChange={setSelectedValue}
+              onChange={handleValueChange}
               placeholder="선택하세요."
               errorMessage="필수 항목입니다."
               noOptionMessage="항목을 선택하세요."

--- a/packages/web/src/common/components/Table/TableCell.tsx
+++ b/packages/web/src/common/components/Table/TableCell.tsx
@@ -54,6 +54,7 @@ const CommonCellBodyWrapper = styled.td.withConfig({
 const CellText = styled.div.withConfig({
   shouldForwardProp: prop => isPropValid(prop),
 })<{ isGray: boolean; isSelect?: boolean }>`
+  display: flex;
   font-size: 14px;
   line-height: 14px;
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
@@ -61,6 +62,8 @@ const CellText = styled.div.withConfig({
     isGray ? theme.colors.GRAY[100] : theme.colors.BLACK};
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
+  justify-content: center;
 `;
 
 const HeaderInner = styled.div`

--- a/packages/web/src/common/components/TagSelect/SelectOption.tsx
+++ b/packages/web/src/common/components/TagSelect/SelectOption.tsx
@@ -6,6 +6,7 @@ const SelectOption = styled.div.withConfig({
 })<{ selectable?: boolean; selected?: boolean }>`
   display: flex;
   align-items: center;
+  justify-content: center;
   align-self: stretch;
   width: 100%;
   gap: 8px;

--- a/packages/web/src/common/components/TagSelect/index.tsx
+++ b/packages/web/src/common/components/TagSelect/index.tsx
@@ -44,6 +44,7 @@ const SelectInner = styled.div`
   position: relative;
   height: 24px;
   overflow-y: visible;
+  width: fit-content;
 `;
 
 const StyledSelect = styled.div.withConfig({

--- a/packages/web/src/features/budget/components/ManagerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ManagerIncomeTable.tsx
@@ -41,19 +41,16 @@ import InputSelect, {
   SelectItem,
 } from "@sparcs-students/web/common/components/InputSelect"; // SelectItem,
 import TableTextInput from "@sparcs-students/web/common/components/Forms/TableTextInput";
-import { ManagerIncomeProps } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+// import { ManagerIncomeProps } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
 import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import Icon from "@sparcs-students/web/common/components/Icon";
 import isPropValid from "@emotion/is-prop-valid";
 import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 import colors from "@sparcs-students/web/styles/themes/colors";
-
-interface FormValues {
-  incomes: ManagerIncomeProps[];
-}
+import { FormValues } from "@sparcs-students/web/features/budget/type/managerFormValues";
 
 interface ManagerIncomeTableProps {
-  initialData: ManagerIncomeProps[];
+  formMethods: ReturnType<typeof useForm<FormValues>>;
   isProposal: boolean;
 }
 
@@ -82,7 +79,6 @@ const TableHeaderWrapper = styled.tr`
   align-items: center;
   border-radius: 4px 4px 0px 0px;
   overflow: hidden;
-  width: fit-content;
 `;
 
 const TableContentWrapper = styled.tbody`
@@ -103,7 +99,7 @@ const TableRowWrapper = styled.tr.withConfig({
   background: ${({ theme }) => theme.colors.WHITE};
   cursor: pointer;
   overflow-y: visible;
-  width: fit-content;
+  //width: fit-content;
 `;
 
 const TitleWithButtonWrapper = styled.div`
@@ -260,7 +256,7 @@ const TableRow: React.FC<TableRowProps> = ({
       <Controller
         name={`incomes.${rowIndex}.item`}
         render={({ field }) => (
-          <TableCell type="Default" width="400px">
+          <TableCell type="Default" width={0}>
             <InputSelect
               items={itemList}
               value={field.value}
@@ -376,19 +372,13 @@ const TableRow: React.FC<TableRowProps> = ({
 };
 
 const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
-  initialData,
+  formMethods,
   isProposal,
 }) => {
   const [dynamicHeight, setDynamicHeight] = React.useState<number | undefined>(
     334, // TODO: magic number 36 + 48 + 250
   );
-  const formMethods = useForm<FormValues>({
-    defaultValues: {
-      incomes: initialData,
-    },
-  });
-
-  const { handleSubmit, control, setValue, getValues } = formMethods;
+  const { control, setValue, getValues } = formMethods;
   const { fields, append, remove } = useFieldArray({
     control,
     name: "incomes",
@@ -468,13 +458,9 @@ const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
     }, 0);
   };
 
-  const onSubmit = (data: FormValues) => {
-    console.log("Submitted incomes:", data.incomes);
-  };
-
   return (
     <FormProvider {...formMethods}>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form>
         <FlexWrapper direction="column" gap={16}>
           <TitleWithButtonWrapper>
             <Typography fs={24} lh={30} color="BLACK" fw="SEMIBOLD">
@@ -502,7 +488,7 @@ const ManagerIncomeTable: React.FC<ManagerIncomeTableProps> = ({
                   <TableCell type="Header" width="150px">
                     예산 분류
                   </TableCell>
-                  <TableCell type="Header" width="400px">
+                  <TableCell type="Header" width={0}>
                     항목
                   </TableCell>
                   <TableCell type="Header" width="130px">

--- a/packages/web/src/features/budget/components/ReviewerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ReviewerIncomeTable.tsx
@@ -32,6 +32,7 @@ import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum
 
 export interface IncomeProps {
   code: number;
+  id: number;
   budgetDomain: BudgetDomainEnum;
   budgetDivisionIncome: BudgetDivisionIncomeEnum;
   item: string;

--- a/packages/web/src/features/budget/components/ReviewerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ReviewerIncomeTable.tsx
@@ -45,6 +45,11 @@ export interface IncomeProps {
 
 interface IncomeTableProps {
   initialData: IncomeProps[];
+  onReviewUpdate: (data: {
+    code: number;
+    reviewText: string;
+    reviewStatus: DocumentReviewStatusEnum;
+  }) => void;
 }
 
 const columnHelper = createColumnHelper<IncomeProps>();
@@ -93,7 +98,8 @@ const getColumns = (
     id: "item",
     header: "항목",
     cell: info => info.getValue(),
-    size: 275,
+    size: 0,
+    minSize: 275,
   }),
   columnHelper.accessor("lastYear", {
     id: "lastYear",
@@ -171,7 +177,10 @@ const getColumns = (
   }),
 ];
 
-const ReviewerIncomeTable: React.FC<IncomeTableProps> = ({ initialData }) => {
+const ReviewerIncomeTable: React.FC<IncomeTableProps> = ({
+  initialData,
+  onReviewUpdate,
+}) => {
   const [data, setData] = useState(initialData);
   const [loaded, setLoaded] = useState(false);
 
@@ -180,22 +189,44 @@ const ReviewerIncomeTable: React.FC<IncomeTableProps> = ({ initialData }) => {
   }, []);
 
   const handleReviewChange = (code: number, newReview: string) => {
-    setData(prevData =>
-      prevData.map(item =>
+    setData(prevData => {
+      const newData = prevData.map(item =>
         item.code === code ? { ...item, review: newReview } : item,
-      ),
-    );
+      );
+
+      const matched = newData.find(d => d.code === code);
+      if (matched) {
+        onReviewUpdate({
+          code,
+          reviewText: matched.review,
+          reviewStatus: matched.status,
+        });
+      }
+
+      return newData;
+    });
   };
 
   const handleStatusChange = (
     code: number,
     newStatus: DocumentReviewStatusEnum,
   ) => {
-    setData(prevData =>
-      prevData.map(item =>
+    setData(prevData => {
+      const newData = prevData.map(item =>
         item.code === code ? { ...item, status: newStatus } : item,
-      ),
-    );
+      );
+
+      const matched = newData.find(d => d.code === code);
+      if (matched) {
+        onReviewUpdate({
+          code,
+          reviewText: matched.review,
+          reviewStatus: matched.status,
+        });
+      }
+
+      return newData;
+    });
   };
 
   const columns = getColumns(handleReviewChange, handleStatusChange);

--- a/packages/web/src/features/budget/components/ViewerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ViewerIncomeTable.tsx
@@ -31,6 +31,7 @@ import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum
 
 export interface ViewerIncomeProps {
   code: number;
+  id: number;
   budgetDomain: BudgetDomainEnum;
   budgetDivisionIncome: BudgetDivisionIncomeEnum;
   item: string;

--- a/packages/web/src/features/budget/components/ViewerIncomeTable.tsx
+++ b/packages/web/src/features/budget/components/ViewerIncomeTable.tsx
@@ -86,7 +86,8 @@ const columns = [
     id: "item",
     header: "항목",
     cell: info => info.getValue(),
-    size: 400,
+    size: 0,
+    minSize: 400,
   }),
   columnHelper.accessor("lastYear", {
     id: "lastYear",

--- a/packages/web/src/features/budget/frames/ManagerBudgetProposalFrame.tsx
+++ b/packages/web/src/features/budget/frames/ManagerBudgetProposalFrame.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React from "react";
+import { useForm } from "react-hook-form";
+import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
+import Button from "@sparcs-students/web/common/components/Buttons/Button";
+
+import TotalTable from "@sparcs-students/web/features/documents/components/TotalTable";
+import {
+  mockManagerExpenditureData,
+  mockManagerIncomeData,
+  mockManagerProjectNameCandidateList,
+  mockViewResultData,
+} from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+import styled from "styled-components";
+import { overlay } from "overlay-kit";
+import Modal from "@sparcs-students/web/common/components/Modal";
+import ConfirmModalContent from "@sparcs-students/web/common/components/Modal/ConfirmModalContent";
+import CancellableModalContent from "@sparcs-students/web/common/components/Modal/CancellableModalContent";
+import ManagerIncomeTable from "@sparcs-students/web/features/budget/components/ManagerIncomeTable";
+import ManagerExpenditureTable from "@sparcs-students/web/features/documents/components/ManagerExpenditureTable";
+import { FormValues } from "@sparcs-students/web/features/budget/type/managerFormValues";
+
+import { dataToTotal } from "@sparcs-students/web/features/budget/util/dataToTotal";
+
+const ButtonWrapper = styled.div`
+  gap: 30px;
+  flex-direction: row;
+  display: flex;
+  justify-content: center;
+`;
+
+const Proposal = () => {
+  const formMethods = useForm<FormValues>({
+    defaultValues: {
+      incomes: mockManagerIncomeData,
+      expenditures: mockManagerExpenditureData,
+    },
+  });
+
+  const handleSubmitAll = () => {
+    // CHACHA: 백에 넘어가야 할 데이터들?
+    const incomeData = formMethods.getValues("incomes");
+    const expenditureData = formMethods.getValues("expenditures");
+    const submissionDate = mockViewResultData.submitDate;
+
+    console.log("제출할 income 데이터:", incomeData);
+    console.log("제출할 expenditure 데이터:", expenditureData);
+    console.log("제출 날짜:", submissionDate);
+    console.log("제출하는 문서의 정보:", mockViewResultData);
+  };
+
+  const handleResetAll = () => {
+    formMethods.reset({
+      incomes: mockManagerIncomeData,
+      expenditures: mockManagerExpenditureData,
+    });
+  };
+
+  const openSaveModal = () => {
+    // TODO: add save logic
+    overlay.open(({ isOpen, close }) => (
+      <Modal isOpen={isOpen} width="400px">
+        <ConfirmModalContent
+          onConfirm={() => {
+            handleSubmitAll();
+            close();
+          }}
+        >
+          저장되었습니다.
+        </ConfirmModalContent>
+      </Modal>
+    ));
+  };
+
+  const openDiscardModal = () => {
+    // TODO: add discard logic
+    overlay.open(({ isOpen, close }) => (
+      <Modal isOpen={isOpen} width="400px">
+        <CancellableModalContent
+          onConfirm={() => {
+            handleResetAll();
+            close();
+          }}
+          onClose={() => close()}
+        >
+          임시저장 내역을{"\n"}모두 삭제하시겠습니까?
+        </CancellableModalContent>
+      </Modal>
+    ));
+  };
+
+  return (
+    <FlexWrapper direction="column" gap={48}>
+      <FlexWrapper direction="column" gap={60} style={{ padding: "20 0px" }}>
+        <ManagerIncomeTable formMethods={formMethods} isProposal />
+        <ManagerExpenditureTable
+          formMethods={formMethods}
+          projectNameCandidate={mockManagerProjectNameCandidateList}
+          isProposal
+        />
+        <TotalTable
+          data={dataToTotal(
+            formMethods.getValues("incomes"),
+            formMethods.getValues("expenditures"),
+          )}
+        />
+        <ButtonWrapper>
+          <Button
+            type="reverse"
+            onClick={openDiscardModal}
+            style={{ width: "100px", padding: "8px 16px" }}
+          >
+            삭제
+          </Button>
+          <Button
+            onClick={openSaveModal}
+            style={{ width: "100px", padding: "8px 16px" }}
+          >
+            제출
+          </Button>
+        </ButtonWrapper>
+      </FlexWrapper>
+    </FlexWrapper>
+  );
+};
+export default Proposal;

--- a/packages/web/src/features/budget/frames/ManagerBudgetReportFrame.tsx
+++ b/packages/web/src/features/budget/frames/ManagerBudgetReportFrame.tsx
@@ -30,7 +30,7 @@ const ButtonWrapper = styled.div`
   justify-content: center;
 `;
 
-const ManagerBudgetProposalFrame = () => {
+const ManagerBudgetReportFrame = () => {
   const formMethods = useForm<FormValues>({
     defaultValues: {
       incomes: mockManagerIncomeData,
@@ -93,11 +93,11 @@ const ManagerBudgetProposalFrame = () => {
   return (
     <FlexWrapper direction="column" gap={48}>
       <FlexWrapper direction="column" gap={60} style={{ padding: "20 0px" }}>
-        <ManagerIncomeTable formMethods={formMethods} isProposal />
+        <ManagerIncomeTable formMethods={formMethods} isProposal={false} />
         <ManagerExpenditureTable
           formMethods={formMethods}
           projectNameCandidate={mockManagerProjectNameCandidateList}
-          isProposal
+          isProposal={false}
         />
         <TotalTable
           data={dataToTotal(
@@ -124,4 +124,4 @@ const ManagerBudgetProposalFrame = () => {
     </FlexWrapper>
   );
 };
-export default ManagerBudgetProposalFrame;
+export default ManagerBudgetReportFrame;

--- a/packages/web/src/features/budget/frames/ReviewerBudgetProposalFrame.tsx
+++ b/packages/web/src/features/budget/frames/ReviewerBudgetProposalFrame.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { useForm } from "react-hook-form";
+import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
+import Button from "@sparcs-students/web/common/components/Buttons/Button";
+
+import TotalTable from "@sparcs-students/web/features/documents/components/TotalTable";
+import {
+  mockExpenditureData,
+  mockIncomeData,
+  mockViewResultData,
+} from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+
+import styled from "styled-components";
+import { overlay } from "overlay-kit";
+import Modal from "@sparcs-students/web/common/components/Modal";
+import ConfirmModalContent from "@sparcs-students/web/common/components/Modal/ConfirmModalContent";
+import CancellableModalContent from "@sparcs-students/web/common/components/Modal/CancellableModalContent";
+import { FormValues } from "@sparcs-students/web/features/budget/type/managerFormValues";
+import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
+import ReviewerExpenditureTable from "@sparcs-students/web/features/documents/components/ReviewerExpenditureTable";
+
+import { dataToTotal } from "@sparcs-students/web/features/budget/util/dataToTotal";
+import { DocumentReviewStatusEnum } from "@sparcs-students/root/packages/interface/src/common/enum";
+
+const ButtonWrapper = styled.div`
+  gap: 30px;
+  flex-direction: row;
+  display: flex;
+  justify-content: center;
+`;
+
+const ReviewerBudgetProposal = () => {
+  const { id } = useParams();
+  const [resetKey, setResetKey] = useState(0);
+
+  const initialReviewData = useMemo(() => {
+    const income = mockIncomeData.map(item => ({
+      code: item.code,
+      reviewText: item.review,
+      reviewStatus: item.status,
+    }));
+
+    const expenditure = mockExpenditureData.map(item => ({
+      code: item.code,
+      reviewText: item.review,
+      reviewStatus: item.status,
+    }));
+
+    return { income, expenditure };
+  }, [resetKey]);
+
+  const [reviewData, setReviewData] = useState<{
+    income: {
+      code: number;
+      reviewText: string;
+      reviewStatus: DocumentReviewStatusEnum;
+    }[];
+    expenditure: {
+      code: number;
+      reviewText: string;
+      reviewStatus: DocumentReviewStatusEnum;
+    }[];
+  }>(initialReviewData);
+
+  const formMethods = useForm<FormValues>({
+    defaultValues: {
+      incomes: mockIncomeData,
+      expenditures: mockExpenditureData,
+    },
+  });
+
+  const handleSubmitAll = () => {
+    // CHACHA: 백에 넘어가야 할 데이터들?
+    const review = reviewData;
+    console.log("리뷰하는 문서의 정보:", mockViewResultData);
+    console.log("제출된 리뷰:", review);
+  };
+
+  const handleResetAll = () => {
+    formMethods.reset({
+      incomes: mockIncomeData,
+      expenditures: mockExpenditureData,
+    });
+    setReviewData(initialReviewData);
+    setResetKey(prev => prev + 1); // CHACHA: re-render
+  };
+
+  const updatedIncomeData = useMemo(
+    () =>
+      mockIncomeData.map(item => {
+        const reviewEntry = reviewData.income.find(d => d.code === item.code);
+        return reviewEntry
+          ? {
+              ...item,
+              review: reviewEntry.reviewText,
+              status: reviewEntry.reviewStatus,
+            }
+          : item;
+      }),
+    [reviewData.income],
+  );
+
+  const updatedExpenditureData = useMemo(
+    () =>
+      mockExpenditureData.map(item => {
+        const reviewEntry = reviewData.expenditure.find(
+          d => d.code === item.code,
+        );
+        return reviewEntry
+          ? {
+              ...item,
+              review: reviewEntry.reviewText,
+              status: reviewEntry.reviewStatus,
+            }
+          : item;
+      }),
+    [reviewData.expenditure],
+  );
+
+  const openSaveModal = () => {
+    // TODO: add save logic
+    overlay.open(({ isOpen, close }) => (
+      <Modal isOpen={isOpen} width="400px">
+        <ConfirmModalContent
+          onConfirm={() => {
+            handleSubmitAll();
+            close();
+          }}
+        >
+          저장되었습니다.
+        </ConfirmModalContent>
+      </Modal>
+    ));
+  };
+
+  const openDiscardModal = () => {
+    // TODO: add discard logic
+    overlay.open(({ isOpen, close }) => (
+      <Modal isOpen={isOpen} width="400px">
+        <CancellableModalContent
+          onConfirm={() => {
+            handleResetAll();
+            close();
+          }}
+          onClose={() => close()}
+        >
+          임시저장 내역을{"\n"}모두 삭제하시겠습니까?
+        </CancellableModalContent>
+      </Modal>
+    ));
+  };
+
+  return (
+    <FlexWrapper direction="column" gap={60} style={{ padding: "20 0px" }}>
+      <ReviewerIncomeTable
+        key={`income-${resetKey}`}
+        initialData={updatedIncomeData}
+        onReviewUpdate={({ code, reviewText, reviewStatus }) => {
+          setReviewData(prev => {
+            const newIncome = [...prev.income];
+            const existingIndex = newIncome.findIndex(d => d.code === code);
+            const newEntry = { code, reviewText, reviewStatus };
+
+            if (existingIndex >= 0) {
+              newIncome[existingIndex] = newEntry;
+            } else {
+              newIncome.push(newEntry);
+            }
+
+            return { ...prev, income: newIncome };
+          });
+        }}
+      />
+      <ReviewerExpenditureTable
+        key={`expenditure-${resetKey}`}
+        type="proposal"
+        pageId={id}
+        initialData={updatedExpenditureData}
+        onReviewUpdate={({ code, reviewText, reviewStatus }) => {
+          setReviewData(prev => {
+            const newExpenditure = [...prev.expenditure];
+            const existingIndex = newExpenditure.findIndex(
+              d => d.code === code,
+            );
+            const newEntry = { code, reviewText, reviewStatus };
+
+            if (existingIndex >= 0) {
+              newExpenditure[existingIndex] = newEntry;
+            } else {
+              newExpenditure.push(newEntry);
+            }
+
+            return { ...prev, expenditure: newExpenditure };
+          });
+        }}
+      />
+      <TotalTable data={dataToTotal(mockIncomeData, mockExpenditureData)} />
+      <ButtonWrapper>
+        <Button
+          type="reverse"
+          onClick={openDiscardModal}
+          style={{ width: "100px", padding: "8px 16px" }}
+        >
+          삭제
+        </Button>
+        <Button
+          onClick={openSaveModal}
+          style={{ width: "100px", padding: "8px 16px" }}
+        >
+          제출
+        </Button>
+      </ButtonWrapper>
+    </FlexWrapper>
+  );
+};
+export default ReviewerBudgetProposal;

--- a/packages/web/src/features/budget/frames/ReviewerBudgetReportFrame.tsx
+++ b/packages/web/src/features/budget/frames/ReviewerBudgetReportFrame.tsx
@@ -11,15 +11,13 @@ import {
   mockIncomeData,
   mockViewResultData,
 } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
-
-import styled from "styled-components";
+import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
+import ReviewerExpenditureTable from "@sparcs-students/web/features/documents/components/ReviewerExpenditureTable";
 import { overlay } from "overlay-kit";
 import Modal from "@sparcs-students/web/common/components/Modal";
 import ConfirmModalContent from "@sparcs-students/web/common/components/Modal/ConfirmModalContent";
 import CancellableModalContent from "@sparcs-students/web/common/components/Modal/CancellableModalContent";
-import ReviewerIncomeTable from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
-import ReviewerExpenditureTable from "@sparcs-students/web/features/documents/components/ReviewerExpenditureTable";
-
+import styled from "styled-components";
 import { dataToTotal } from "@sparcs-students/web/features/budget/util/dataToTotal";
 import { DocumentReviewStatusEnum } from "@sparcs-students/root/packages/interface/src/common/enum";
 
@@ -30,7 +28,7 @@ const ButtonWrapper = styled.div`
   justify-content: center;
 `;
 
-const ReviewerBudgetProposalFrame = () => {
+const ReviewerBudgetReportFrame = () => {
   const { id } = useParams();
   const [resetKey, setResetKey] = useState(0);
 
@@ -203,4 +201,4 @@ const ReviewerBudgetProposalFrame = () => {
     </FlexWrapper>
   );
 };
-export default ReviewerBudgetProposalFrame;
+export default ReviewerBudgetReportFrame;

--- a/packages/web/src/features/budget/frames/ViewerBudgetProposalFrame.tsx
+++ b/packages/web/src/features/budget/frames/ViewerBudgetProposalFrame.tsx
@@ -15,7 +15,7 @@ import {
 
 import { dataToTotal } from "@sparcs-students/web/features/budget/util/dataToTotal";
 
-const ViewerBudgetProposal = () => {
+const ViewerBudgetProposalFrame = () => {
   const { id } = useParams();
 
   return (
@@ -32,4 +32,4 @@ const ViewerBudgetProposal = () => {
     </FlexWrapper>
   );
 };
-export default ViewerBudgetProposal;
+export default ViewerBudgetProposalFrame;

--- a/packages/web/src/features/budget/frames/ViewerBudgetProposalFrame.tsx
+++ b/packages/web/src/features/budget/frames/ViewerBudgetProposalFrame.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React from "react";
+import { useParams } from "next/navigation";
+
+import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
+
+import ViewerIncomeTable from "@sparcs-students/web/features/budget/components/ViewerIncomeTable";
+import ViewerExpenditureTable from "@sparcs-students/web/features/documents/components/ViewerExpenditureTable";
+import TotalTable from "@sparcs-students/web/features/documents/components/TotalTable";
+import {
+  mockViewerExpenditureData,
+  mockViewerIncomeData,
+} from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+
+import { dataToTotal } from "@sparcs-students/web/features/budget/util/dataToTotal";
+
+const ViewerBudgetProposal = () => {
+  const { id } = useParams();
+
+  return (
+    <FlexWrapper direction="column" gap={60} style={{ padding: "20 0px" }}>
+      <ViewerIncomeTable data={mockViewerIncomeData} />
+      <ViewerExpenditureTable
+        data={mockViewerExpenditureData}
+        type="proposal"
+        pageId={id}
+      />
+      <TotalTable
+        data={dataToTotal(mockViewerIncomeData, mockViewerExpenditureData)}
+      />
+    </FlexWrapper>
+  );
+};
+export default ViewerBudgetProposal;

--- a/packages/web/src/features/budget/frames/ViewerBudgetReportFrame.tsx
+++ b/packages/web/src/features/budget/frames/ViewerBudgetReportFrame.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import { useParams } from "next/navigation";
+import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
+
+import TotalTable from "@sparcs-students/web/features/documents/components/TotalTable";
+import {
+  mockExpenditureData,
+  mockIncomeData,
+} from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+
+import ViewerExpenditureTable from "@sparcs-students/web/features/documents/components/ViewerExpenditureTable";
+import ViewerIncomeTable from "@sparcs-students/web/features/budget/components/ViewerIncomeTable";
+import { dataToTotal } from "@sparcs-students/web/features/budget/util/dataToTotal";
+
+const ViewerBudgetReportFrame = () => {
+  const { id } = useParams();
+  return (
+    <FlexWrapper direction="column" gap={48}>
+      <FlexWrapper direction="column" gap={60} style={{ padding: "20 0px" }}>
+        <ViewerIncomeTable data={mockIncomeData} />
+        <ViewerExpenditureTable
+          data={mockExpenditureData}
+          type="report"
+          pageId={id}
+        />
+        <TotalTable data={dataToTotal(mockIncomeData, mockExpenditureData)} />
+      </FlexWrapper>
+    </FlexWrapper>
+  );
+};
+export default ViewerBudgetReportFrame;

--- a/packages/web/src/features/budget/services/_mock/mockProposalTableData.ts
+++ b/packages/web/src/features/budget/services/_mock/mockProposalTableData.ts
@@ -41,6 +41,7 @@ export const mockViewProjectResultData: ViewResultProps = {
 export const mockViewerIncomeData: ViewerIncomeProps[] = [
   {
     code: 101,
+    id: 0,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.Substratum,
     item: "기층기구회계 지원금",
@@ -54,6 +55,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
   },
   {
     code: 102,
+    id: 1,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.Substratum,
     item: "기층기구회계 지원금",
@@ -67,6 +69,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
   },
   {
     code: 103,
+    id: 2,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.Substratum,
     item: "기층기구회계 지원금",
@@ -80,6 +83,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
   },
   {
     code: 201,
+    id: 3,
     budgetDomain: BudgetDomainEnum.School,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.School,
     item: "기층기구회계 지원금",
@@ -96,6 +100,7 @@ export const mockViewerIncomeData: ViewerIncomeProps[] = [
 export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
   {
     code: 401,
+    id: 0,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",
@@ -108,6 +113,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
   },
   {
     code: 402,
+    id: 1,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",
@@ -120,6 +126,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
   },
   {
     code: 403,
+    id: 2,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",
@@ -132,6 +139,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
   },
   {
     code: 501,
+    id: 3,
     budgetDomain: BudgetDomainEnum.School,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",
@@ -146,6 +154,7 @@ export const mockViewerExpenditureData: ViewerExpenditureProps[] = [
 export const mockIncomeData: IncomeProps[] = [
   {
     code: 101,
+    id: 0,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.Substratum,
     item: "기층기구회계 지원금",
@@ -159,6 +168,7 @@ export const mockIncomeData: IncomeProps[] = [
   },
   {
     code: 102,
+    id: 1,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.Substratum,
     item: "기층기구회계 지원금",
@@ -172,6 +182,7 @@ export const mockIncomeData: IncomeProps[] = [
   },
   {
     code: 103,
+    id: 2,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.Substratum,
     item: "기층기구회계 지원금",
@@ -185,6 +196,7 @@ export const mockIncomeData: IncomeProps[] = [
   },
   {
     code: 201,
+    id: 3,
     budgetDomain: BudgetDomainEnum.School,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.School,
     item: "기층기구회계 지원금",
@@ -200,6 +212,7 @@ export const mockIncomeData: IncomeProps[] = [
 
 export interface ManagerIncomeProps {
   code: number;
+  id: number;
   budgetDomain: BudgetDomainEnum;
   budgetDivisionIncome: BudgetDivisionIncomeEnum;
   item: string;
@@ -214,6 +227,7 @@ export interface ManagerIncomeProps {
 export const mockManagerIncomeData: ManagerIncomeProps[] = [
   {
     code: 0,
+    id: 0,
     budgetDomain: BudgetDomainEnum.Undefined,
     budgetDivisionIncome: BudgetDivisionIncomeEnum.Undefined,
     item: "",
@@ -228,6 +242,7 @@ export const mockManagerIncomeData: ManagerIncomeProps[] = [
 
 export interface ManagerExpenditureProps {
   code: number;
+  id: number;
   budgetDomain: BudgetDomainEnum;
   budgetDivisionExpenditure: BudgetDivisionExpenseEnum | undefined;
   projectName: string;
@@ -243,6 +258,7 @@ export interface ManagerExpenditureProps {
 export const mockManagerExpenditureData: ManagerExpenditureProps[] = [
   {
     code: 401,
+    id: 0,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionExpenditure: BudgetDivisionExpenseEnum.Operating,
     projectName: "격려금",
@@ -274,6 +290,7 @@ export const mockManagerProjectNameCandidateList: ManagerProjectNameCandidate[] 
 export const mockExpenditureData: ExpenditureProps[] = [
   {
     code: 401,
+    id: 0,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",
@@ -287,6 +304,7 @@ export const mockExpenditureData: ExpenditureProps[] = [
   },
   {
     code: 402,
+    id: 1,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",
@@ -300,6 +318,7 @@ export const mockExpenditureData: ExpenditureProps[] = [
   },
   {
     code: 403,
+    id: 2,
     budgetDomain: BudgetDomainEnum.Student,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",
@@ -313,6 +332,7 @@ export const mockExpenditureData: ExpenditureProps[] = [
   },
   {
     code: 501,
+    id: 3,
     budgetDomain: BudgetDomainEnum.School,
     budgetDivisionExpense: BudgetDivisionExpenseEnum.Operating,
     name: "격려금",

--- a/packages/web/src/features/budget/services/_mock/mockProposalTableData.ts
+++ b/packages/web/src/features/budget/services/_mock/mockProposalTableData.ts
@@ -9,7 +9,7 @@ import { ViewerExpenditureProps } from "@sparcs-students/web/features/documents/
 import { ViewResultProps } from "@sparcs-students/web/features/documents/components/ViewResult";
 import { IncomeProps } from "@sparcs-students/web/features/budget/components/ReviewerIncomeTable";
 import { ExpenditureProps } from "@sparcs-students/web/features/documents/components/ReviewerExpenditureTable";
-import { ManagerExpenditureProps } from "@sparcs-students/web/features/documents/components/ManagerExpenditureTable";
+// import { ManagerExpenditureProps } from "@sparcs-students/web/features/documents/components/ManagerExpenditureTable";
 import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 
 export const mockViewResultData: ViewResultProps = {
@@ -225,6 +225,20 @@ export const mockManagerIncomeData: ManagerIncomeProps[] = [
     review: "",
   },
 ];
+
+export interface ManagerExpenditureProps {
+  code: number;
+  budgetDomain: BudgetDomainEnum;
+  budgetDivisionExpenditure: BudgetDivisionExpenseEnum | undefined;
+  projectName: string;
+  item: BudgetClassExpenseEnum;
+  lastYear: number | string;
+  thisYear: number | string;
+  ratio: number | null;
+  reason: string;
+  status: DocumentReviewStatusEnum;
+  review: string;
+}
 
 export const mockManagerExpenditureData: ManagerExpenditureProps[] = [
   {

--- a/packages/web/src/features/budget/type/managerFormValues.ts
+++ b/packages/web/src/features/budget/type/managerFormValues.ts
@@ -1,0 +1,9 @@
+import {
+  ManagerIncomeProps,
+  ManagerExpenditureProps,
+} from "../services/_mock/mockProposalTableData";
+
+export interface FormValues {
+  incomes: ManagerIncomeProps[];
+  expenditures: ManagerExpenditureProps[];
+}

--- a/packages/web/src/features/budget/util/dataToTotal.ts
+++ b/packages/web/src/features/budget/util/dataToTotal.ts
@@ -1,0 +1,115 @@
+import { ViewerIncomeProps } from "@sparcs-students/web/features/budget/components/ViewerIncomeTable";
+import {
+  ManagerExpenditureProps,
+  ManagerIncomeProps,
+} from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
+import { ViewerExpenditureProps } from "@sparcs-students/web/features/documents/components/ViewerExpenditureTable";
+import { BudgetDomainEnum } from "@sparcs-students/root/packages/interface/src/common/enum";
+import { TotalProps } from "@sparcs-students/web/features/documents/components/TotalTable";
+
+interface DomainAccum {
+  incomeLastYear: number;
+  incomeThisYear: number;
+  expenditureLastYear: number;
+  expenditureThisYear: number;
+}
+
+export const dataToTotal = (
+  incomeData: ViewerIncomeProps[] | ManagerIncomeProps[],
+  expenditureData: ViewerExpenditureProps[] | ManagerExpenditureProps[],
+) => {
+  const incomeMap = incomeData.reduce<Record<BudgetDomainEnum, DomainAccum>>(
+    (acc, cur) => {
+      const { budgetDomain, lastYear, thisYear } = cur;
+
+      const prev = acc[budgetDomain] ?? {
+        incomeLastYear: 0,
+        incomeThisYear: 0,
+        expenditureLastYear: 0,
+        expenditureThisYear: 0,
+      };
+
+      return {
+        ...acc,
+        [budgetDomain]: {
+          ...prev,
+          incomeLastYear: prev.incomeLastYear + (lastYear as number),
+          incomeThisYear: prev.incomeThisYear + (thisYear as number),
+        },
+      };
+    },
+    {} as Record<BudgetDomainEnum, DomainAccum>,
+  );
+
+  const combinedMap = expenditureData.reduce<
+    Record<BudgetDomainEnum, DomainAccum>
+  >((acc, cur) => {
+    const { budgetDomain, lastYear, thisYear } = cur;
+
+    const prev = acc[budgetDomain] ?? {
+      incomeLastYear: 0,
+      incomeThisYear: 0,
+      expenditureLastYear: 0,
+      expenditureThisYear: 0,
+    };
+
+    return {
+      ...acc,
+      [budgetDomain]: {
+        ...prev,
+        expenditureLastYear: prev.expenditureLastYear + (lastYear as number),
+        expenditureThisYear: prev.expenditureThisYear + (thisYear as number),
+      },
+    };
+  }, incomeMap);
+
+  const resultArray = Object.entries(combinedMap).reduce<TotalProps[]>(
+    (acc, [key, sums]) => {
+      const domain = Number(key) as BudgetDomainEnum;
+
+      const incomeRow = {
+        budgetDomain: domain,
+        type: "수입",
+        lastYear: sums.incomeLastYear,
+        thisYear: sums.incomeThisYear,
+        ratio:
+          sums.incomeLastYear === 0
+            ? null
+            : (sums.incomeThisYear / sums.incomeLastYear) * 100,
+      };
+
+      const expenditureRow = {
+        budgetDomain: domain,
+        type: "지출",
+        lastYear: sums.expenditureLastYear,
+        thisYear: sums.expenditureThisYear,
+        ratio:
+          sums.expenditureLastYear === 0
+            ? null
+            : (sums.expenditureThisYear / sums.expenditureLastYear) * 100,
+      };
+
+      const totalLastYear = sums.incomeLastYear - sums.expenditureLastYear;
+      const totalThisYear = sums.incomeThisYear - sums.expenditureThisYear;
+      const totalRow = {
+        budgetDomain: domain,
+        type: "총계",
+        lastYear: totalLastYear,
+        thisYear: totalThisYear,
+        ratio:
+          totalLastYear === 0 ? null : (totalThisYear / totalLastYear) * 100,
+      };
+
+      return [...acc, incomeRow, expenditureRow, totalRow];
+    },
+    [] as {
+      budgetDomain: BudgetDomainEnum;
+      type: string;
+      lastYear: number;
+      thisYear: number;
+      ratio: number;
+    }[],
+  );
+
+  return resultArray;
+};

--- a/packages/web/src/features/documents/components/DetailModal.tsx
+++ b/packages/web/src/features/documents/components/DetailModal.tsx
@@ -15,6 +15,7 @@ interface EditableDetailModalProps {
   title: string;
   value: string;
   onChange: (value: string) => void;
+  onClose: () => void;
 }
 
 const ModalContentInner = styled.div`
@@ -36,7 +37,7 @@ const DetailWrapper = styled.div`
 
 const ButtonWrapper = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 `;
 
 const DetailModal: React.FC<DetailModalProps> = ({
@@ -62,6 +63,7 @@ export const EditableDetailModal: React.FC<EditableDetailModalProps> = ({
   title,
   value,
   onChange,
+  onClose,
 }) => {
   const [localText, setLocalText] = useState<string>(value);
 
@@ -80,13 +82,21 @@ export const EditableDetailModal: React.FC<EditableDetailModalProps> = ({
         handleChange={setLocalText}
       />
       <ButtonWrapper>
+        <Button // CHACHA: 디자인에는 없으나 필요할 것 같아서 넣음
+          onClick={() => {
+            onClose();
+          }}
+          type="reverse"
+        >
+          닫기
+        </Button>
         <Button
           onClick={() => {
             onChange(localText);
             onConfirm();
           }}
         >
-          닫기
+          저장
         </Button>
       </ButtonWrapper>
     </ModalContentInner>

--- a/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ManagerExpenditureTable.tsx
@@ -38,7 +38,6 @@ import styled from "styled-components";
 import TableCell from "@sparcs-students/web/common/components/Table/TableCell";
 import InputSelect from "@sparcs-students/web/common/components/InputSelect"; // SelectItem,
 import TableTextInput from "@sparcs-students/web/common/components/Forms/TableTextInput";
-// import { ManagerIncomeProps } from "@sparcs-students/web/features/budget/services/_mock/mockProposalTableData";
 import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import Icon from "@sparcs-students/web/common/components/Icon";
 import isPropValid from "@emotion/is-prop-valid";
@@ -48,20 +47,7 @@ import {
 } from "@sparcs-students/web/utils/getTagDetail";
 import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
 import colors from "@sparcs-students/web/styles/themes/colors";
-
-export interface ManagerExpenditureProps {
-  code: number;
-  budgetDomain: BudgetDomainEnum;
-  budgetDivisionExpenditure: BudgetDivisionExpenseEnum | undefined;
-  projectName: string;
-  item: BudgetClassExpenseEnum;
-  lastYear: number | string;
-  thisYear: number | string;
-  ratio: number | null;
-  reason: string;
-  status: DocumentReviewStatusEnum;
-  review: string;
-}
+import { FormValues } from "@sparcs-students/web/features/budget/type/managerFormValues";
 
 export interface ManagerProjectNameCandidate {
   budgetDomain: BudgetDomainEnum;
@@ -69,12 +55,8 @@ export interface ManagerProjectNameCandidate {
   projectNameCandidate: string[];
 }
 
-interface FormValues {
-  expenditures: ManagerExpenditureProps[];
-}
-
 interface ManagerExpenditureTableProps {
-  initialData: ManagerExpenditureProps[];
+  formMethods: ReturnType<typeof useForm<FormValues>>;
   projectNameCandidate: ManagerProjectNameCandidate[];
   isProposal: boolean;
 }
@@ -104,7 +86,6 @@ const TableHeaderWrapper = styled.tr`
   align-items: center;
   border-radius: 4px 4px 0px 0px;
   overflow: hidden;
-  width: fit-content;
 `;
 
 const TableContentWrapper = styled.tbody`
@@ -124,7 +105,6 @@ const TableRowWrapper = styled.tr.withConfig({
   background: ${({ theme }) => theme.colors.WHITE};
   cursor: pointer;
   overflow-y: visible;
-  width: fit-content;
 `;
 
 const TitleWithButtonWrapper = styled.div`
@@ -276,7 +256,7 @@ const TableRow: React.FC<TableRowProps> = ({
       <Controller
         name={`expenditures.${rowIndex}.projectName`}
         render={({ field }) => (
-          <TableCell type="Default" width="400px">
+          <TableCell type="Default" width={0}>
             <InputSelect
               items={setProjectNameListInputItem(getProjectNameCandidateList())}
               value={field.value}
@@ -419,19 +399,13 @@ const TableRow: React.FC<TableRowProps> = ({
 };
 
 const ManagerExpenditureTable: React.FC<ManagerExpenditureTableProps> = ({
-  initialData,
+  formMethods,
   projectNameCandidate,
   isProposal,
 }) => {
   const [dynamicHeight, setDynamicHeight] = React.useState<number | undefined>(
     334, // TODO: magic number 36 + 48 + 250
   );
-
-  const formMethods = useForm<FormValues>({
-    defaultValues: {
-      expenditures: initialData,
-    },
-  });
 
   const { handleSubmit, control, setValue, getValues } = formMethods;
   const { fields, append, remove } = useFieldArray({
@@ -547,7 +521,7 @@ const ManagerExpenditureTable: React.FC<ManagerExpenditureTableProps> = ({
                   <TableCell type="Header" width="150px">
                     예산 분류
                   </TableCell>
-                  <TableCell type="Header" width="400px">
+                  <TableCell type="Header" width={0}>
                     사업명
                   </TableCell>
                   <TableCell type="Header" width="142px">

--- a/packages/web/src/features/documents/components/ReviewerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ReviewerExpenditureTable.tsx
@@ -45,6 +45,7 @@ import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.share
 
 export interface ExpenditureProps {
   code: number;
+  id: number;
   budgetDomain: BudgetDomainEnum;
   budgetDivisionExpense: BudgetDivisionExpenseEnum;
   name: string;

--- a/packages/web/src/features/documents/components/ReviewerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ReviewerExpenditureTable.tsx
@@ -37,6 +37,9 @@ import { budgetExpenseToString } from "@sparcs-students/web/features/documents/u
 import ExpenditureHelpButton from "@sparcs-students/web/features/documents/components/_atomic/ExpenditureHelpButton";
 import ReviewButton from "@sparcs-students/web/features/documents/components/_atomic/ReviewButton";
 import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
+import { useRouter } from "next/navigation";
+import HoverClickText from "@sparcs-students/web/common/components/HoverClickText";
+import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 // ExpenditureProps 인터페이스는 위에 정의된 대로 사용
 
@@ -56,6 +59,13 @@ export interface ExpenditureProps {
 
 interface ExpenditureTableProps {
   initialData: ExpenditureProps[];
+  pageId: string | string[];
+  type: string; // "proposal" || "report"
+  onReviewUpdate: (data: {
+    code: number;
+    reviewText: string;
+    reviewStatus: DocumentReviewStatusEnum;
+  }) => void;
 }
 
 const columnHelper = createColumnHelper<ExpenditureProps>();
@@ -66,6 +76,9 @@ const getColumns = (
     code: number,
     newStatus: DocumentReviewStatusEnum,
   ) => void,
+  type: string,
+  pageId: string | string[],
+  router: AppRouterInstance,
 ) => [
   columnHelper.accessor("code", {
     id: "code",
@@ -103,7 +116,17 @@ const getColumns = (
   columnHelper.accessor("name", {
     id: "name",
     header: "사업명",
-    cell: info => info.getValue(),
+    cell: info => (
+      <HoverClickText
+        text={info.getValue()}
+        onClick={() =>
+          router.push(
+            `/document-lookup/project-${type}/result/${pageId}/detail/${info.row.id}`,
+            // CHACHA: 만약 n개의 row가 같은 상세 페이지 내의 항목이라면? row.id가 not unique...?
+          )
+        }
+      />
+    ),
     size: 210,
   }),
   columnHelper.accessor("item", {
@@ -120,7 +143,8 @@ const getColumns = (
         <LightTag color={color}>{text}</LightTag>
       );
     },
-    size: 180,
+    size: 0,
+    minSize: 180,
   }),
   columnHelper.accessor("lastYear", {
     id: "lastYear",
@@ -202,34 +226,65 @@ const getColumns = (
 
 const ReviewerExpenditureTable: React.FC<ExpenditureTableProps> = ({
   initialData,
+  pageId,
+  type,
+  onReviewUpdate,
 }) => {
   const [data, setData] = useState<ExpenditureProps[]>(initialData);
   const [loaded, setLoaded] = useState(false);
-
+  const router = useRouter();
   useEffect(() => {
     setLoaded(true);
   }, []);
 
   const handleReviewChange = (code: number, newReview: string) => {
-    setData(prevData =>
-      prevData.map(item =>
+    setData(prevData => {
+      const newData = prevData.map(item =>
         item.code === code ? { ...item, review: newReview } : item,
-      ),
-    );
+      );
+
+      const matched = newData.find(d => d.code === code);
+      if (matched) {
+        onReviewUpdate({
+          code: matched.code,
+          reviewText: matched.review,
+          reviewStatus: matched.status,
+        });
+      }
+
+      return newData;
+    });
   };
 
   const handleStatusChange = (
     code: number,
     newStatus: DocumentReviewStatusEnum,
   ) => {
-    setData(prevData =>
-      prevData.map(item =>
+    setData(prevData => {
+      const newData = prevData.map(item =>
         item.code === code ? { ...item, status: newStatus } : item,
-      ),
-    );
+      );
+
+      const matched = newData.find(d => d.code === code);
+      if (matched) {
+        onReviewUpdate({
+          code: matched.code,
+          reviewText: matched.review,
+          reviewStatus: matched.status,
+        });
+      }
+
+      return newData;
+    });
   };
 
-  const columns = getColumns(handleReviewChange, handleStatusChange);
+  const columns = getColumns(
+    handleReviewChange,
+    handleStatusChange,
+    type,
+    pageId,
+    router,
+  );
 
   const table = useReactTable({
     columns,

--- a/packages/web/src/features/documents/components/ThreeInput/index.tsx
+++ b/packages/web/src/features/documents/components/ThreeInput/index.tsx
@@ -37,7 +37,7 @@ interface ThreeInputProps {
   selectedValue: string | null;
   setSelectedValue: (value: string | null) => void;
   // selectedId: number | null;
-  setSelectedId: (value: number | null) => void;
+  setSelectedId?: (value: number | null) => void;
 }
 
 const OuterWrapper = styled.div`
@@ -76,7 +76,7 @@ const ThreeInput: React.FC<ThreeInputProps> = ({
   setSelectedKey,
   selectedValue,
   setSelectedValue,
-  setSelectedId,
+  setSelectedId = () => {},
 }: ThreeInputProps) => {
   // CHACHA: 학기 선택에 쓰임
   const selectItems = useMemo(() => {

--- a/packages/web/src/features/documents/components/ThreeInput/index.tsx
+++ b/packages/web/src/features/documents/components/ThreeInput/index.tsx
@@ -36,6 +36,8 @@ interface ThreeInputProps {
   setSelectedKey: (key: string | null) => void;
   selectedValue: string | null;
   setSelectedValue: (value: string | null) => void;
+  // selectedId: number | null;
+  setSelectedId: (value: number | null) => void;
 }
 
 const OuterWrapper = styled.div`
@@ -74,6 +76,7 @@ const ThreeInput: React.FC<ThreeInputProps> = ({
   setSelectedKey,
   selectedValue,
   setSelectedValue,
+  setSelectedId,
 }: ThreeInputProps) => {
   // CHACHA: 학기 선택에 쓰임
   const selectItems = useMemo(() => {
@@ -96,9 +99,14 @@ const ThreeInput: React.FC<ThreeInputProps> = ({
   const keyList = useMemo(() => totalList.map(e => e.key), [totalList]);
 
   useEffect(() => {
+    if (selectedKey && selectedValue) return;
+
     setSelectedKey("");
     setSelectedValue("");
-  }, [type, setSelectedKey, setSelectedValue]);
+    if (setSelectedId) {
+      setSelectedId(null);
+    }
+  }, [type, setSelectedKey, setSelectedValue, selectedKey, selectedValue]);
 
   return (
     <OuterWrapper>
@@ -123,6 +131,7 @@ const ThreeInput: React.FC<ThreeInputProps> = ({
         setSelectedKey={setSelectedKey}
         selectedValue={selectedValue ?? ""}
         setSelectedValue={setSelectedValue}
+        setSelectedId={setSelectedId}
         disabled={year === null || isSpring === null || type === null}
       />
     </OuterWrapper>

--- a/packages/web/src/features/documents/components/ThreeInput/mock.ts
+++ b/packages/web/src/features/documents/components/ThreeInput/mock.ts
@@ -29,9 +29,9 @@ export const mockData: ThreeInputItem[] = [
           {
             key: { label: "어떤 집단 2", value: "어떤 집단 2" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 4 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 5 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 6 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],
@@ -56,17 +56,17 @@ export const mockData: ThreeInputItem[] = [
           {
             key: { label: "어떤 집단 3", value: "어떤 집단 3" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 6 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 7 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 8 },
             ],
           },
           {
             key: { label: "어떤 집단 4", value: "어떤 집단 4" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 9 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 10 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 11 },
             ],
           },
         ],
@@ -91,17 +91,17 @@ export const mockData: ThreeInputItem[] = [
           {
             key: { label: "어떤 집단 5", value: "어떤 집단 5" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 12 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 13 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 14 },
             ],
           },
           {
             key: { label: "어떤 집단 6", value: "어떤 집단 6" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 15 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 16 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 17 },
             ],
           },
         ],
@@ -126,17 +126,17 @@ export const mockData: ThreeInputItem[] = [
           {
             key: { label: "어떤 집단 7", value: "어떤 집단 7" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 18 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 19 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 20 },
             ],
           },
           {
             key: { label: "어떤 집단 8", value: "어떤 집단 8" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 21 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 22 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 23 },
             ],
           },
         ],
@@ -161,17 +161,17 @@ export const mockData: ThreeInputItem[] = [
           {
             key: { label: "어떤 집단 9", value: "어떤 집단 9" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 24 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 25 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 26 },
             ],
           },
           {
             key: { label: "어떤 집단 10", value: "어떤 집단 10" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 27 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 28 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 29 },
             ],
           },
         ],
@@ -191,22 +191,22 @@ export const mockData: ThreeInputItem[] = [
           DocumentType.ProjectProposal,
           DocumentType.ProjectReport,
         ],
-        selectedType: DocumentType.ProjectProposal,
+        selectedType: DocumentType.BudgetReport,
         organization: [
           {
             key: { label: "어떤 집단 11", value: "어떤 집단 11" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 30 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 31 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 32 },
             ],
           },
           {
             key: { label: "어떤 집단 12", value: "어떤 집단 12" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 33 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 34 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 35 },
             ],
           },
         ],
@@ -231,17 +231,17 @@ export const mockData: ThreeInputItem[] = [
           {
             key: { label: "어떤 집단 13", value: "어떤 집단 13" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 36 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 37 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 38 },
             ],
           },
           {
             key: { label: "어떤 집단 14", value: "어떤 집단 14" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 39 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 40 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 41 },
             ],
           },
         ],
@@ -266,17 +266,17 @@ export const mockData: ThreeInputItem[] = [
           {
             key: { label: "어떤 집단 15", value: "어떤 집단 15" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 42 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 43 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 44 },
             ],
           },
           {
             key: { label: "어떤 집단 16", value: "어떤 집단 16" },
             values: [
-              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
-              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
-              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 45 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 46 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 47 },
             ],
           },
         ],

--- a/packages/web/src/features/documents/components/ThreeInput/mock.ts
+++ b/packages/web/src/features/documents/components/ThreeInput/mock.ts
@@ -5,8 +5,8 @@ import { ThreeInputItem } from "@sparcs-students/web/features/documents/componen
 export const mockData: ThreeInputItem[] = [
   {
     id: 0,
-    label: "2022년도",
-    year: 2022,
+    label: "2024년도",
+    year: 2024,
     value: {
       isSpring: true,
       documentType: {
@@ -19,22 +19,19 @@ export const mockData: ThreeInputItem[] = [
         selectedType: DocumentType.BudgetProposal,
         organization: [
           {
-            key: { label: "개발자1", value: "개발자1" },
+            key: { label: "어떤 집단 1", value: "어떤 집단 1" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너1", value: "디자이너1" },
+            key: { label: "어떤 집단 2", value: "어떤 집단 2" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 4 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 5 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 6 },
             ],
           },
         ],
@@ -43,8 +40,8 @@ export const mockData: ThreeInputItem[] = [
   },
   {
     id: 1,
-    label: "2022년도",
-    year: 2022,
+    label: "2024년도",
+    year: 2024,
     value: {
       isSpring: true,
       documentType: {
@@ -57,22 +54,19 @@ export const mockData: ThreeInputItem[] = [
         selectedType: DocumentType.ProjectProposal,
         organization: [
           {
-            key: { label: "개발자2", value: "개발자2" },
+            key: { label: "어떤 집단 3", value: "어떤 집단 3" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너2", value: "디자이너2" },
+            key: { label: "어떤 집단 4", value: "어떤 집단 4" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],
@@ -81,8 +75,8 @@ export const mockData: ThreeInputItem[] = [
   },
   {
     id: 2,
-    label: "2022년도",
-    year: 2022,
+    label: "2024년도",
+    year: 2024,
     value: {
       isSpring: false,
       documentType: {
@@ -95,22 +89,19 @@ export const mockData: ThreeInputItem[] = [
         selectedType: DocumentType.ProjectProposal,
         organization: [
           {
-            key: { label: "개발자3", value: "개발자3" },
+            key: { label: "어떤 집단 5", value: "어떤 집단 5" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너3", value: "디자이너3" },
+            key: { label: "어떤 집단 6", value: "어떤 집단 6" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],
@@ -119,8 +110,8 @@ export const mockData: ThreeInputItem[] = [
   },
   {
     id: 3,
-    label: "2022년도",
-    year: 2022,
+    label: "2024년도",
+    year: 2024,
     value: {
       isSpring: false,
       documentType: {
@@ -133,22 +124,19 @@ export const mockData: ThreeInputItem[] = [
         selectedType: DocumentType.ProjectReport,
         organization: [
           {
-            key: { label: "개발자4", value: "개발자4" },
+            key: { label: "어떤 집단 7", value: "어떤 집단 7" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너4", value: "디자이너4" },
+            key: { label: "어떤 집단 8", value: "어떤 집단 8" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],
@@ -157,8 +145,8 @@ export const mockData: ThreeInputItem[] = [
   },
   {
     id: 4,
-    label: "2023년도",
-    year: 2023,
+    label: "2025년도",
+    year: 2025,
     value: {
       isSpring: true,
       documentType: {
@@ -168,25 +156,22 @@ export const mockData: ThreeInputItem[] = [
           DocumentType.ProjectProposal,
           DocumentType.ProjectReport,
         ],
-        selectedType: DocumentType.BudgetReport,
+        selectedType: DocumentType.BudgetProposal,
         organization: [
           {
-            key: { label: "개발자5", value: "개발자5" },
+            key: { label: "어떤 집단 9", value: "어떤 집단 9" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너5", value: "디자이너5" },
+            key: { label: "어떤 집단 10", value: "어떤 집단 10" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],
@@ -195,8 +180,8 @@ export const mockData: ThreeInputItem[] = [
   },
   {
     id: 5,
-    label: "2023년도",
-    year: 2023,
+    label: "2025년도",
+    year: 2025,
     value: {
       isSpring: true,
       documentType: {
@@ -209,22 +194,19 @@ export const mockData: ThreeInputItem[] = [
         selectedType: DocumentType.ProjectProposal,
         organization: [
           {
-            key: { label: "개발자6", value: "개발자6" },
+            key: { label: "어떤 집단 11", value: "어떤 집단 11" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너6", value: "디자이너6" },
+            key: { label: "어떤 집단 12", value: "어떤 집단 12" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],
@@ -233,8 +215,8 @@ export const mockData: ThreeInputItem[] = [
   },
   {
     id: 6,
-    label: "2023년도",
-    year: 2023,
+    label: "2025년도",
+    year: 2025,
     value: {
       isSpring: false,
       documentType: {
@@ -247,22 +229,19 @@ export const mockData: ThreeInputItem[] = [
         selectedType: DocumentType.ProjectProposal,
         organization: [
           {
-            key: { label: "개발자7", value: "개발자7" },
+            key: { label: "어떤 집단 13", value: "어떤 집단 13" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너7", value: "디자이너7" },
+            key: { label: "어떤 집단 14", value: "어떤 집단 14" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],
@@ -271,8 +250,8 @@ export const mockData: ThreeInputItem[] = [
   },
   {
     id: 7,
-    label: "2023년도",
-    year: 2023,
+    label: "2025년도",
+    year: 2025,
     value: {
       isSpring: false,
       documentType: {
@@ -285,22 +264,19 @@ export const mockData: ThreeInputItem[] = [
         selectedType: DocumentType.ProjectReport,
         organization: [
           {
-            key: { label: "개발자8", value: "개발자8" },
+            key: { label: "어떤 집단 15", value: "어떤 집단 15" },
             values: [
-              { label: "chacha", value: "chacha" },
-              { label: "eel", value: "eel" },
-              { label: "malloc", value: "malloc" },
-              { label: "casio", value: "casio" },
-              { label: "gb", value: "gb" },
-              { label: "mingle", value: "mingle" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 0 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 1 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 2 },
             ],
           },
           {
-            key: { label: "디자이너8", value: "디자이너8" },
+            key: { label: "어떤 집단 16", value: "어떤 집단 16" },
             values: [
-              { label: "somato", value: "somato" },
-              { label: "dudu", value: "dudu" },
-              { label: "siwon", value: "siwon" },
+              { label: "어떤 단체 1", value: "어떤 단체 1", id: 3 },
+              { label: "어떤 단체 2", value: "어떤 단체 2", id: 4 },
+              { label: "어떤 단체 3", value: "어떤 단체 3", id: 5 },
             ],
           },
         ],

--- a/packages/web/src/features/documents/components/TotalTable.tsx
+++ b/packages/web/src/features/documents/components/TotalTable.tsx
@@ -67,7 +67,8 @@ const columns = [
         currency: "KRW",
       });
     },
-    size: 522,
+    size: 0,
+    minSize: 400,
   }),
   columnHelper.accessor("thisYear", {
     id: "thisYear",
@@ -79,7 +80,8 @@ const columns = [
         currency: "KRW",
       });
     },
-    size: 522,
+    size: 0,
+    minSize: 400,
   }),
   columnHelper.accessor("ratio", {
     id: "ratio",

--- a/packages/web/src/features/documents/components/ViewerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ViewerExpenditureTable.tsx
@@ -43,6 +43,7 @@ import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.share
 
 export interface ViewerExpenditureProps {
   code: number;
+  id: number;
   budgetDomain: BudgetDomainEnum;
   budgetDivisionExpense: BudgetDivisionExpenseEnum;
   name: string;

--- a/packages/web/src/features/documents/components/ViewerExpenditureTable.tsx
+++ b/packages/web/src/features/documents/components/ViewerExpenditureTable.tsx
@@ -38,6 +38,8 @@ import { budgetExpenseToString } from "@sparcs-students/web/features/documents/u
 import ExpenditureHelpButton from "@sparcs-students/web/features/documents/components/_atomic/ExpenditureHelpButton";
 import { useRouter } from "next/navigation";
 import { DocumentReviewStatusEnum } from "@sparcs-students/interface/common/enum/meeting.enum";
+import HoverClickText from "@sparcs-students/web/common/components/HoverClickText";
+import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 export interface ViewerExpenditureProps {
   code: number;
@@ -60,7 +62,11 @@ interface ExpenditureTableProps {
 
 const columnHelper = createColumnHelper<ViewerExpenditureProps>();
 
-const columns = [
+const getColumns = (
+  type: string,
+  pageId: string | string[],
+  router: AppRouterInstance,
+) => [
   columnHelper.accessor("code", {
     id: "code",
     header: "코드",
@@ -97,7 +103,17 @@ const columns = [
   columnHelper.accessor("name", {
     id: "name",
     header: "사업명",
-    cell: info => info.getValue(),
+    cell: info => (
+      <HoverClickText
+        text={info.getValue()}
+        onClick={() =>
+          router.push(
+            `/document-lookup/project-${type}/result/${pageId}/detail/${info.row.id}`,
+            // CHACHA: 만약 n개의 row가 같은 상세 페이지 내의 항목이라면? row.id가 not unique...?
+          )
+        }
+      />
+    ),
     size: 140,
   }),
   columnHelper.accessor("item", {
@@ -114,7 +130,8 @@ const columns = [
         <LightTag color={color}>{text}</LightTag>
       );
     },
-    size: 175,
+    size: 0,
+    minSize: 175,
   }),
   columnHelper.accessor("lastYear", {
     id: "lastYear",
@@ -186,6 +203,8 @@ const ViewerExpenditureTable: React.FC<ExpenditureTableProps> = ({
     setLoaded(true);
   }, []);
 
+  const columns = getColumns(type, pageId, router);
+
   const table = useReactTable({
     columns,
     data,
@@ -201,17 +220,7 @@ const ViewerExpenditureTable: React.FC<ExpenditureTableProps> = ({
         </Typography>
         <ExpenditureHelpButton />
       </FlexWrapper>
-      {loaded && (
-        <Table
-          table={table}
-          emptyMessage="테이블 정보가 없습니다."
-          onClick={row =>
-            router.push(
-              `/document-lookup/project-${type}/result/${pageId}/detail/${row.code}`, // TODO: change when api connect
-            )
-          }
-        />
-      )}
+      {loaded && <Table table={table} emptyMessage="테이블 정보가 없습니다." />}
     </FlexWrapper>
   );
 };

--- a/packages/web/src/features/documents/components/_atomic/DetailButton.tsx
+++ b/packages/web/src/features/documents/components/_atomic/DetailButton.tsx
@@ -29,6 +29,9 @@ export const EditableDetailButton = ({
           onConfirm={() => {
             close();
           }}
+          onClose={() => {
+            close();
+          }}
           title={`${projectItem}에 대한 비고`}
           value={value}
           onChange={onChange}

--- a/packages/web/src/features/documents/components/_atomic/ExpenditureHelpButton.tsx
+++ b/packages/web/src/features/documents/components/_atomic/ExpenditureHelpButton.tsx
@@ -13,7 +13,7 @@ const ToolTipWrapper = styled.div`
   line-height: 20px;
   text-align: center;
 
-  width: 340px;
+  width: fit-content;
   box-shadow: 0px 8px 8px rgba(0, 0, 0, 0.25);
   border-radius: 4px;
   position: absolute;
@@ -38,7 +38,7 @@ const ExpenditureHelpButton = () => {
       />
       {showTooltip && (
         <ToolTipWrapper>
-          지출 항목을 클릭하면 각 사업의 상세 설명을 확인할 수 있습니다.
+          사업명을 클릭하면 각 사업의 상세 설명을 확인할 수 있습니다.
         </ToolTipWrapper>
       )}
     </FlexWrapper>


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #167

1. 예산안, 결산안 매니저 페이지 구현 완료, react-hook-form으로 깔끔하게 데이터 받을 수 있습니다.
2. 그리고 예산안, 결산안 페이지가 권한 관리 때문에 코드 주석 처리하고 그러느라 지저분한 감이 있어서, 권한마다 frame으로 분리하여 보다 깔끔하게 정리했습니다!
3. 조회 가이드로 검색하면 이제 조회 결과 뜰 때 뭘로 검색했는지 반영 됩니다.
4. 어떤 반기 + 어떤 문서 + 어떤 단체냐에 따라 id를 다 다르게 주는 것도 목 데이터에 반영 해 놨으니, url로 확인 가능하실 거에요!
5. 어떤 반기, 어떤 문서, 어떤 단체로 검색했는지 query Param으로 넘기게 해 놨는데.. 어떤지 모르겠어요 하하 회의 때 여쭤보겠습니다
6. 테이블 이상하던 거 일단 예결산은 수정 다 했습니다아

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

https://github.com/user-attachments/assets/5d568c67-f8b4-4f14-bfef-8c9d386aa0f0



# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
