### PR TITLE
Group detail add

### DIFF
--- a/packages/web/src/common/components/Forms/TextInput.tsx
+++ b/packages/web/src/common/components/Forms/TextInput.tsx
@@ -10,6 +10,7 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   errorMessage?: string;
   disabled?: boolean;
   constant?: boolean;
+  isGroup?: boolean;
   value?: string;
   handleChange?: (value: string) => void;
   setErrorStatus?: (hasError: boolean) => void;
@@ -27,6 +28,11 @@ export const disabledStyle = css`
 const constantStyle = css`
   border-color: ${({ theme }) => theme.colors.GRAY[100]};
   cursor: not-allowed;
+`;
+
+const groupConstantStyle = css`
+  background-color: ${({ theme }) => theme.colors.GRAY[50]};
+  color: ${({ theme }) => theme.colors.GRAY[100]};
 `;
 
 const Input = styled.input.attrs<TextInputProps>(({ constant }) => ({
@@ -59,6 +65,7 @@ const Input = styled.input.attrs<TextInputProps>(({ constant }) => ({
   ${({ constant }) => constant && constantStyle}
   ${({ disabled }) => disabled && disabledStyle}
   ${({ hasError }) => hasError && errorBorderStyle}
+  ${({ constant, isGroup }) => isGroup && constant && groupConstantStyle}
 `;
 
 export const InputWrapper = styled.div`

--- a/packages/web/src/features/document-lookup/project/components/GroupList.tsx
+++ b/packages/web/src/features/document-lookup/project/components/GroupList.tsx
@@ -1,23 +1,45 @@
-import React from "react";
+import React, { useState } from "react";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
 import GroupDetail, {
   GroupProps,
 } from "@sparcs-students/web/features/document-lookup/project/components/_atomic/GroupDetail";
+import Button from "@sparcs-students/web/common/components/Buttons/Button";
 
 interface GroupListProps {
   data: GroupProps[];
+  isEditable: boolean;
 }
 
-const GroupList: React.FC<GroupListProps> = ({ data }) => (
-  <FlexWrapper direction="column" gap={16}>
-    <Typography fs={20} lh={28} color="BLACK" fw="SEMIBOLD">
-      국서/TF 구조
-    </Typography>
-    {data.map(group => (
-      <GroupDetail {...group} />
-    ))}
-  </FlexWrapper>
-);
+const GroupList: React.FC<GroupListProps> = ({ data, isEditable }) => {
+  const [tmpData, setTmpData] = useState(data);
+  return (
+    <FlexWrapper direction="column" gap={16}>
+      <FlexWrapper direction="row" gap={0} justify="space-between">
+        <Typography
+          fs={20}
+          lh={28}
+          color="BLACK"
+          fw="SEMIBOLD"
+          style={{ whiteSpace: "nowrap" }}
+        >
+          국서/TF 구조
+        </Typography>
+        {isEditable && (
+          <Button
+            buttonText="저장"
+            style={{ width: "60px", padding: "5px 0px", fontSize: "14px" }}
+            onClick={() => {
+              console.log(tmpData);
+            }}
+          />
+        )}
+      </FlexWrapper>
+      {tmpData.map(group => (
+        <GroupDetail {...group} setTmpData={setTmpData} isEditable />
+      ))}
+    </FlexWrapper>
+  );
+};
 
 export default GroupList;

--- a/packages/web/src/features/document-lookup/project/components/OperationPlan.tsx
+++ b/packages/web/src/features/document-lookup/project/components/OperationPlan.tsx
@@ -7,6 +7,7 @@ import GroupList from "@sparcs-students/web/features/document-lookup/project/com
 import { GroupProps } from "@sparcs-students/web/features/document-lookup/project/components/_atomic/GroupDetail";
 import Image from "next/image";
 import styled from "styled-components";
+import { UserPermission } from "@sparcs-students/web/constants/userPermission";
 import MemberTable, { MemberProps } from "./MemberTable";
 
 export interface OperationPlanProps {
@@ -15,6 +16,7 @@ export interface OperationPlanProps {
   groupList: GroupProps[];
   imagePath: string;
   isProposal?: boolean;
+  userPermission?: UserPermission;
 }
 
 const StyledImage = styled(Image)`
@@ -28,6 +30,7 @@ const OperationPlan: React.FC<OperationPlanProps> = ({
   groupList,
   imagePath,
   isProposal = true,
+  userPermission = UserPermission.Viewer,
 }) => (
   <FlexWrapper direction="column" gap={60}>
     <FlexWrapper direction="column" gap={16}>
@@ -42,7 +45,10 @@ const OperationPlan: React.FC<OperationPlanProps> = ({
       </Typography>
       <TextInput placeholder="비고 입력" value={note} constant />
     </FlexWrapper>
-    <GroupList data={groupList} />
+    <GroupList
+      data={groupList}
+      isEditable={userPermission === UserPermission.Manager}
+    />
     <FlexWrapper direction="column" gap={16}>
       <Typography fs={20} lh={28} color="BLACK" fw="SEMIBOLD">
         조직도

--- a/packages/web/src/features/document-lookup/project/components/_atomic/GroupDetail.tsx
+++ b/packages/web/src/features/document-lookup/project/components/_atomic/GroupDetail.tsx
@@ -28,13 +28,29 @@ const FoldableInner = styled.div`
   gap: 10px;
 `;
 
-const GroupList: React.FC<GroupProps> = ({
+const GroupList: React.FC<
+  GroupProps & {
+    setTmpData?: React.Dispatch<React.SetStateAction<GroupProps[]>>;
+    isEditable: boolean;
+  }
+> = ({
   name,
   summary,
   members,
   projectName,
+  setTmpData = () => {},
+  isEditable,
 }) => {
   const [folded, setFolded] = useState(true);
+
+  const handleSummaryChange = (newSummary: string) => {
+    // TODO: 일단 name 기준으로 했는데 나중에 실제 데이터는 id 등으로 비교해야 할 듯
+    setTmpData(prev =>
+      prev.map(group =>
+        group.name === name ? { ...group, summary: newSummary } : group,
+      ),
+    );
+  };
 
   return (
     <CardWrapper>
@@ -62,8 +78,13 @@ const GroupList: React.FC<GroupProps> = ({
             <Typography fs={20} lh={28} color="BLACK" fw="SEMIBOLD">
               활동 요약
             </Typography>
-            <TextInput placeholder="활동요약" value={summary} isGroup />
-            {/* <TextInput placeholder="활동요약" value={summary} constant={userPermission !== UserPermission.Manager} isGroup handleChange={handleSummaryChange} /> */}
+            <TextInput
+              placeholder="활동요약"
+              value={summary}
+              constant={!isEditable}
+              isGroup
+              handleChange={handleSummaryChange}
+            />
           </FlexWrapper>
           <FlexWrapper direction="column" gap={10}>
             <Typography fs={20} lh={28} color="BLACK" fw="SEMIBOLD">

--- a/packages/web/src/features/document-lookup/project/components/_atomic/GroupDetail.tsx
+++ b/packages/web/src/features/document-lookup/project/components/_atomic/GroupDetail.tsx
@@ -54,7 +54,7 @@ const GroupList: React.FC<GroupProps> = ({
             {folded ? "펼치기" : "접기"}
           </Typography>
         </FoldableInner>
-        <TextInput placeholder="국서명" value={name} constant />
+        <TextInput placeholder="국서명" value={name} constant isGroup />
       </FlexWrapper>
       {!folded && (
         <FlexWrapper direction="column" gap={10}>
@@ -62,7 +62,8 @@ const GroupList: React.FC<GroupProps> = ({
             <Typography fs={20} lh={28} color="BLACK" fw="SEMIBOLD">
               활동 요약
             </Typography>
-            <TextInput placeholder="활동요약" value={summary} constant />
+            <TextInput placeholder="활동요약" value={summary} isGroup />
+            {/* <TextInput placeholder="활동요약" value={summary} constant={userPermission !== UserPermission.Manager} isGroup handleChange={handleSummaryChange} /> */}
           </FlexWrapper>
           <FlexWrapper direction="column" gap={10}>
             <Typography fs={20} lh={28} color="BLACK" fw="SEMIBOLD">
@@ -72,13 +73,19 @@ const GroupList: React.FC<GroupProps> = ({
               placeholder="국서/TF원 명단"
               value={members.join(", ")}
               constant
+              isGroup
             />
           </FlexWrapper>
           <FlexWrapper direction="column" gap={10}>
             <Typography fs={20} lh={28} color="BLACK" fw="SEMIBOLD">
               사업명
             </Typography>
-            <TextInput placeholder="사업명" value={projectName} constant />
+            <TextInput
+              placeholder="사업명"
+              value={projectName}
+              constant
+              isGroup
+            />
           </FlexWrapper>
         </FlexWrapper>
       )}

--- a/packages/web/src/features/document-lookup/project/frames/ManagerProjectProposalFrame.tsx
+++ b/packages/web/src/features/document-lookup/project/frames/ManagerProjectProposalFrame.tsx
@@ -15,6 +15,7 @@ import ConfirmModalContent from "@sparcs-students/web/common/components/Modal/Co
 import CancellableModalContent from "@sparcs-students/web/common/components/Modal/CancellableModalContent";
 import styled from "styled-components";
 import { mockViewProjectProposalResultData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockViewResultData";
+import { UserPermission } from "@sparcs-students/web/constants/userPermission";
 
 const ButtonWrapper = styled.div`
   gap: 30px;
@@ -71,7 +72,10 @@ const ReviewerProjectProposalFrame = () => {
   return (
     <FlexWrapper direction="column" gap={60} style={{ padding: "20 0px" }}>
       {/* <ProjectTable pageId={id} data={mockViewerProjectData} isProposal /> */}
-      <OperationPlan {...mockOperationPlanData} />
+      <OperationPlan
+        {...mockOperationPlanData}
+        userPermission={UserPermission.Manager}
+      />
       <ReviewOperationPlan review={review} reviewHandler={setReview} />
       <ButtonWrapper>
         <Button


### PR DESCRIPTION
# 요약 \*

국서/TF 카드 디자인 수정 및 활동 요약 수정 기능 추가 (저장버튼 클릭시 console.log로 수정된 데이터 확인 가능)

It closes #issue_number

# 스크린샷

![image](https://github.com/user-attachments/assets/917c1f70-eae1-4c1a-b12a-1f485e0e4bc4)

# 이후 Task \*

[] API 연결