### PR TITLE
Fix ref errors on input

### DIFF
--- a/packages/web/src/common/components/Forms/TextAreaInput.tsx
+++ b/packages/web/src/common/components/Forms/TextAreaInput.tsx
@@ -10,6 +10,7 @@ import {
   InputContainer,
 } from "./TextInput";
 
+/* eslint-disable react/require-default-props */
 export interface TextAreaInputProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
@@ -21,6 +22,7 @@ export interface TextAreaInputProps
   handleChange?: (value: string) => void;
   setErrorStatus?: (hasError: boolean) => void;
 }
+/* eslint-enable react/require-default-props */
 
 const StyledTextArea = styled.textarea.withConfig({
   shouldForwardProp: prop => isPropValid(prop),
@@ -56,49 +58,55 @@ const StyledTextArea = styled.textarea.withConfig({
   ${({ hasError }) => hasError && errorBorderStyle}
 `;
 
-const TextAreaInput: React.FC<TextAreaInputProps> = ({
-  label = "",
-  placeholder,
-  errorMessage = "",
-  disabled = false,
-  value = "",
-  handleChange = () => {},
-  setErrorStatus = () => {},
-  id,
-  height = 190,
-  ...props
-}) => {
-  const handleValueChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    const inputValue = e.target.value;
-    handleChange(inputValue);
-  };
+const TextAreaInput = React.forwardRef<HTMLTextAreaElement, TextAreaInputProps>(
+  (
+    {
+      label = "",
+      placeholder,
+      errorMessage = "",
+      disabled = false,
+      value = "",
+      handleChange = () => {},
+      setErrorStatus = () => {},
+      id,
+      height = 190,
+      ...props
+    },
+    ref,
+  ) => {
+    const handleValueChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      const inputValue = e.target.value;
+      handleChange(inputValue);
+    };
 
-  useEffect(() => {
-    const hasError = !!errorMessage;
-    if (setErrorStatus) {
-      setErrorStatus(hasError);
-    }
-  }, [errorMessage, setErrorStatus]);
+    useEffect(() => {
+      const hasError = !!errorMessage;
+      if (setErrorStatus) {
+        setErrorStatus(hasError);
+      }
+    }, [errorMessage, setErrorStatus]);
 
-  return (
-    <InputWrapper>
-      {label && <Label>{label}</Label>}
-      <InputContainer>
-        <StyledTextArea
-          id={id}
-          placeholder={placeholder}
-          hasError={!!errorMessage}
-          disabled={disabled}
-          value={value}
-          onChange={handleValueChange}
-          aria-invalid={!!errorMessage}
-          {...props}
-          height={height}
-        />
-        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
-      </InputContainer>
-    </InputWrapper>
-  );
-};
+    return (
+      <InputWrapper>
+        {label && <Label>{label}</Label>}
+        <InputContainer>
+          <StyledTextArea
+            ref={ref}
+            id={id}
+            placeholder={placeholder}
+            hasError={!!errorMessage}
+            disabled={disabled}
+            value={value}
+            onChange={handleValueChange}
+            aria-invalid={!!errorMessage}
+            {...props}
+            height={height}
+          />
+          {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+        </InputContainer>
+      </InputWrapper>
+    );
+  },
+);
 
 export default TextAreaInput;

--- a/packages/web/src/common/components/Forms/TextInput.tsx
+++ b/packages/web/src/common/components/Forms/TextInput.tsx
@@ -11,6 +11,7 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   errorMessage?: string;
   disabled?: boolean;
   constant?: boolean;
+  isGroup?: boolean;
   value?: string;
   handleChange?: (value: string) => void;
   setErrorStatus?: (hasError: boolean) => void;
@@ -29,6 +30,11 @@ export const disabledStyle = css`
 const constantStyle = css`
   border-color: ${({ theme }) => theme.colors.GRAY[100]};
   cursor: not-allowed;
+`;
+
+const groupConstantStyle = css`
+  background-color: ${({ theme }) => theme.colors.GRAY[50]};
+  color: ${({ theme }) => theme.colors.GRAY[100]};
 `;
 
 const Input = styled.input
@@ -65,6 +71,7 @@ const Input = styled.input
   ${({ constant }) => constant && constantStyle}
   ${({ disabled }) => disabled && disabledStyle}
   ${({ hasError }) => hasError && errorBorderStyle}
+  ${({ constant, isGroup }) => isGroup && constant && groupConstantStyle}
 `;
 
 export const InputWrapper = styled.div`
@@ -89,6 +96,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
       errorMessage = "",
       disabled = false,
       constant = false,
+      isGroup = false,
       value = "",
       handleChange = () => {},
       setErrorStatus = () => {},
@@ -118,6 +126,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
             hasError={!!errorMessage}
             disabled={disabled}
             constant={constant}
+            isGroup={isGroup}
             value={value}
             onChange={handleValueChange}
             {...props}

--- a/packages/web/src/common/components/Forms/TextInput.tsx
+++ b/packages/web/src/common/components/Forms/TextInput.tsx
@@ -1,20 +1,21 @@
 import React, { ChangeEvent, InputHTMLAttributes, useEffect } from "react";
 import styled, { css } from "styled-components";
+import isPropValid from "@emotion/is-prop-valid";
 import Label from "./_atomic/Label";
 import ErrorMessage from "./_atomic/ErrorMessage";
 
-// PhoneInput, RentalInput에서 사용하기 위해 export
+/* eslint-disable react/require-default-props */
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   placeholder: string;
   errorMessage?: string;
   disabled?: boolean;
   constant?: boolean;
-  isGroup?: boolean;
   value?: string;
   handleChange?: (value: string) => void;
   setErrorStatus?: (hasError: boolean) => void;
 }
+/* eslint-enable react/require-default-props */
 
 export const errorBorderStyle = css`
   border-color: ${({ theme }) => theme.colors.RED[700]};
@@ -30,14 +31,13 @@ const constantStyle = css`
   cursor: not-allowed;
 `;
 
-const groupConstantStyle = css`
-  background-color: ${({ theme }) => theme.colors.GRAY[50]};
-  color: ${({ theme }) => theme.colors.GRAY[100]};
-`;
-
-const Input = styled.input.attrs<TextInputProps>(({ constant }) => ({
-  readOnly: constant,
-}))<TextInputProps & { hasError: boolean }>`
+const Input = styled.input
+  .withConfig({
+    shouldForwardProp: prop => isPropValid(prop),
+  })
+  .attrs<TextInputProps>(({ constant }) => ({
+    readOnly: constant,
+  }))<TextInputProps & { hasError: boolean }>`
   display: block;
   width: 100%;
   padding: 8px 12px 8px 12px;
@@ -65,7 +65,6 @@ const Input = styled.input.attrs<TextInputProps>(({ constant }) => ({
   ${({ constant }) => constant && constantStyle}
   ${({ disabled }) => disabled && disabledStyle}
   ${({ hasError }) => hasError && errorBorderStyle}
-  ${({ constant, isGroup }) => isGroup && constant && groupConstantStyle}
 `;
 
 export const InputWrapper = styled.div`
@@ -82,45 +81,52 @@ export const InputContainer = styled.div`
   align-items: center;
 `;
 
-// Component
-const TextInput: React.FC<TextInputProps> = ({
-  label = "",
-  placeholder,
-  errorMessage = "",
-  disabled = false,
-  value = "",
-  handleChange = () => {},
-  setErrorStatus = () => {},
-  ...props
-}) => {
-  const handleValueChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const inputValue = e.target.value;
-    handleChange(inputValue);
-  };
+const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
+  (
+    {
+      label = "",
+      placeholder,
+      errorMessage = "",
+      disabled = false,
+      constant = false,
+      value = "",
+      handleChange = () => {},
+      setErrorStatus = () => {},
+      ...props
+    },
+    ref,
+  ) => {
+    const handleValueChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const inputValue = e.target.value;
+      handleChange(inputValue);
+    };
 
-  useEffect(() => {
-    const hasError = !!errorMessage;
-    if (setErrorStatus) {
-      setErrorStatus(hasError);
-    }
-  }, [errorMessage, setErrorStatus]);
+    useEffect(() => {
+      const hasError = !!errorMessage;
+      if (setErrorStatus) {
+        setErrorStatus(hasError);
+      }
+    }, [errorMessage, setErrorStatus]);
 
-  return (
-    <InputWrapper>
-      {label && <Label>{label}</Label>}
-      <InputContainer>
-        <Input
-          placeholder={placeholder}
-          hasError={!!errorMessage}
-          disabled={disabled}
-          value={value}
-          onChange={handleValueChange}
-          {...props}
-        />
-        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
-      </InputContainer>
-    </InputWrapper>
-  );
-};
+    return (
+      <InputWrapper>
+        {label && <Label>{label}</Label>}
+        <InputContainer>
+          <Input
+            ref={ref}
+            placeholder={placeholder}
+            hasError={!!errorMessage}
+            disabled={disabled}
+            constant={constant}
+            value={value}
+            onChange={handleValueChange}
+            {...props}
+          />
+          {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+        </InputContainer>
+      </InputWrapper>
+    );
+  },
+);
 
 export default TextInput;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #205 
매니저 페이지들에서 훅폼 달면서 생긴 ref 에러들 고쳐놨습니다. 고치다보니까 optional prop에 디폴트값을 줘놔도 인식을 못하는지 자꾸 린트 에러가 걸리는 문제가 있어서 일단 해당 부분에서만 disable해뒀는데 어떻게 해결하는지 아시면 고쳐주시면 감사하겠습니다,,,

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
