### PR TITLE
Organizing button components and applying it to pages

### DIFF
--- a/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/budget-proposal/result/[id]/page.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import ViewResult from "@sparcs-students/web/features/document-lookup/components/ViewResult";
 
 import { mockViewBudgetProposalResultData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockViewResultData";
@@ -24,6 +23,7 @@ import ThreeInput, {
 import getMockUserPermission from "@sparcs-students/web/features/document-lookup/project/services/getMockUserPermission";
 import ViewerBudgetProposalFrame from "@sparcs-students/web/features/document-lookup/budget/frames/ViewerBudgetProposalFrame";
 import ManagerBudgetProposalFrame from "@sparcs-students/web/features/document-lookup/budget/frames/ManagerBudgetProposalFrame";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 
 const BudgetProposal = () => {
   const items: ThreeInputItem[] = mockData;
@@ -107,7 +107,7 @@ const BudgetProposal = () => {
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
-            <Button
+            <ModalTableButton
               buttonText="조회"
               style={{ marginLeft: "auto" }}
               onClick={() => lookUp(selectedId as number)}

--- a/packages/web/src/app/document-lookup/budget-report/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/budget-report/result/[id]/page.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import ViewResult from "@sparcs-students/web/features/document-lookup/components/ViewResult";
 import { mockViewBudgetReportResultData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockViewResultData";
 import PageTitle from "@sparcs-students/web/common/components/PageTitle";
@@ -20,6 +19,7 @@ import ReviewerBudgetReportFrame from "@sparcs-students/web/features/document-lo
 import { useRouter, useSearchParams } from "next/navigation";
 import getMockUserPermission from "@sparcs-students/web/features/document-lookup/project/services/getMockUserPermission";
 import ViewerBudgetReportFrame from "@sparcs-students/web/features/document-lookup/budget/frames/ViewerBudgetReportFrame";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 
 const Report = () => {
   // const { id } = useParams();
@@ -105,7 +105,7 @@ const Report = () => {
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
-            <Button
+            <ModalTableButton
               buttonText="조회"
               style={{ marginLeft: "auto" }}
               onClick={() => lookUp(selectedId as number)}

--- a/packages/web/src/app/document-lookup/page.tsx
+++ b/packages/web/src/app/document-lookup/page.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import PageTitle from "@sparcs-students/web/common/components/PageTitle";
 import { DocumentType } from "@sparcs-students/web/common/components/SelectCard/DocumentTypeSelectCard";
 import { mockData } from "@sparcs-students/web/features/document-lookup/components/ThreeInput/mock";
@@ -13,6 +12,7 @@ import { useRouter } from "next/navigation";
 import ThreeInput, {
   ThreeInputItem,
 } from "@sparcs-students/web/features/document-lookup/components/ThreeInput";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 
 const documentLookUp = () => {
   const items: ThreeInputItem[] = mockData;
@@ -102,7 +102,7 @@ const documentLookUp = () => {
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
-            <Button
+            <ModalTableButton
               buttonText="조회"
               style={{ marginLeft: "auto" }}
               onClick={() => {

--- a/packages/web/src/app/document-lookup/project-proposal/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/project-proposal/result/[id]/page.tsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import ViewResult from "@sparcs-students/web/features/document-lookup/components/ViewResult";
 import { mockViewProjectProposalResultData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockViewResultData";
 import PageTitle from "@sparcs-students/web/common/components/PageTitle";
@@ -19,6 +18,7 @@ import ReviewerProjectProposalFrame from "@sparcs-students/web/features/document
 import getMockUserPermission from "@sparcs-students/web/features/document-lookup/project/services/getMockUserPermission";
 import ViewerProjectProposalFrame from "@sparcs-students/web/features/document-lookup/project/frames/ViewerProjectProposalFrame";
 import ManagerProjectProposalFrame from "@sparcs-students/web/features/document-lookup/project/frames/ManagerProjectProposalFrame";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 
 const Proposal = () => {
   const items: ThreeInputItem[] = mockData;
@@ -107,7 +107,7 @@ const Proposal = () => {
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
-            <Button
+            <ModalTableButton
               buttonText="조회"
               style={{ marginLeft: "auto" }}
               onClick={() => lookUp(selectedId as number)}

--- a/packages/web/src/app/document-lookup/project-report/result/[id]/page.tsx
+++ b/packages/web/src/app/document-lookup/project-report/result/[id]/page.tsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import Typography from "@sparcs-students/web/common/components/Typography";
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import ViewResult from "@sparcs-students/web/features/document-lookup/components/ViewResult";
 import { mockViewProjectReportResultData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockViewResultData";
 import PageTitle from "@sparcs-students/web/common/components/PageTitle";
@@ -19,6 +18,7 @@ import ReviewerProjectReportFrame from "@sparcs-students/web/features/document-l
 import getMockUserPermission from "@sparcs-students/web/features/document-lookup/project/services/getMockUserPermission";
 import ViewerProjectReportFrame from "@sparcs-students/web/features/document-lookup/project/frames/ViewerProjectReportFrame";
 import ManagerProjectReportFrame from "@sparcs-students/web/features/document-lookup/project/frames/ManagerProjectReportFrame";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 
 const Report = () => {
   const items: ThreeInputItem[] = mockData;
@@ -102,7 +102,7 @@ const Report = () => {
             />
           </FlexWrapper>
           <FlexWrapper direction="row" gap={8}>
-            <Button
+            <ModalTableButton
               buttonText="조회"
               style={{ marginLeft: "auto" }}
               onClick={() => lookUp(selectedId as number)}

--- a/packages/web/src/common/components/Buttons/CompButton.tsx
+++ b/packages/web/src/common/components/Buttons/CompButton.tsx
@@ -9,32 +9,27 @@ Custom Children을 넣고자 하면, iconType, buttonText 전달X
 
 "use client";
 
-/*
-
- */
-
 import React, { HTMLAttributes } from "react";
 import styled from "styled-components";
-import Icon from "@sparcs-students/web/common/components/Icon";
 import Typography from "@sparcs-students/web/common/components/Typography";
 
-type ButtonProps = {
+type CompButtonProps = {
   type?: keyof typeof ButtonTypeInner;
   children?: React.ReactNode;
-  iconType?: string;
   buttonText?: string;
   onClick?: (() => void) | ((e: React.MouseEvent<HTMLDivElement>) => void);
 } & HTMLAttributes<HTMLDivElement>;
 
 const ButtonInner = styled.div`
   display: inline-flex;
-  padding: 8px 16px;
+  width: 80px;
+  padding: 8px;
   justify-content: center;
-  align-items: center;
+  align-items: flex-end;
   border-radius: 4px;
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
-  font-size: 16px;
-  line-height: 20px;
+  font-size: 14px;
+  line-height: 14px;
   font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
 `;
 
@@ -47,23 +42,14 @@ const ButtonDefaultInner = styled(ButtonInner)`
 const ButtonReverseInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GREEN[700]};
   background: ${({ theme }) => theme.colors.WHITE};
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[700]};
+  border: 1px solid ${({ theme }) => theme.colors.GREEN[700]};
   cursor: pointer;
-`;
-
-const ButtonOutlinedInner = styled(ButtonInner)`
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[200]};
-  background: ${({ theme }) => theme.colors.WHITE};
-  cursor: pointer;
-  &:hover {
-    border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  }
 `;
 
 const ButtonDisabledInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GRAY[100]};
+  background: ${({ theme }) => theme.colors.WHITE};
   border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  background: ${({ theme }) => theme.colors.GRAY[50]};
   cursor: not-allowed;
 `;
 
@@ -75,7 +61,6 @@ const ButtonIconInner = styled(ButtonInner)`
 const ButtonTypeInner = {
   default: ButtonDefaultInner,
   reverse: ButtonReverseInner,
-  outlined: ButtonOutlinedInner,
   disabled: ButtonDisabledInner,
   icon: ButtonIconInner,
 };
@@ -89,17 +74,6 @@ const ButtonWithTextInner = styled.div`
   display: inline-flex;
 `;
 
-const IconButton = (iconType: string) => (
-  <Icon type={iconType} size={18} color="black" />
-);
-
-const ButtonWithIconAndText = (iconType: string, buttonText: string) => (
-  <ButtonWithTextInner>
-    <Icon type={iconType} size={16} color="white" />
-    <Typography>{buttonText}</Typography>
-  </ButtonWithTextInner>
-);
-
 const ButtonWithText = (buttonText: string) => (
   <ButtonWithTextInner>
     <Typography>{buttonText}</Typography>
@@ -110,19 +84,16 @@ const ButtonWithChildren = (children: React.ReactNode) => (
   <ButtonWithTextInner>{children}</ButtonWithTextInner>
 );
 
-const Button = ({
+const CompButton = ({
   type = "default",
   children = undefined,
-  iconType = "",
   buttonText = "",
 
   ...divProps
-}: ButtonProps) => {
+}: CompButtonProps) => {
   const ButtonChosenInner = ButtonTypeInner[type];
 
   const ButtonContent = () => {
-    if (type === "icon") return IconButton(iconType);
-    if (iconType !== "") return ButtonWithIconAndText(iconType, buttonText);
     if (buttonText !== "") return ButtonWithText(buttonText);
     return ButtonWithChildren(children);
   };
@@ -137,4 +108,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default CompButton;

--- a/packages/web/src/common/components/Buttons/MobileCompButton.tsx
+++ b/packages/web/src/common/components/Buttons/MobileCompButton.tsx
@@ -9,33 +9,30 @@ Custom Children을 넣고자 하면, iconType, buttonText 전달X
 
 "use client";
 
-/*
-
- */
-
 import React, { HTMLAttributes } from "react";
 import styled from "styled-components";
-import Icon from "@sparcs-students/web/common/components/Icon";
 import Typography from "@sparcs-students/web/common/components/Typography";
 
-type ButtonProps = {
+type MobileCompButtonProps = {
   type?: keyof typeof ButtonTypeInner;
   children?: React.ReactNode;
-  iconType?: string;
   buttonText?: string;
   onClick?: (() => void) | ((e: React.MouseEvent<HTMLDivElement>) => void);
 } & HTMLAttributes<HTMLDivElement>;
 
 const ButtonInner = styled.div`
   display: inline-flex;
-  padding: 8px 16px;
+  height: 28px;
+  padding: 4px 8px;
   justify-content: center;
   align-items: center;
-  border-radius: 4px;
+  border-radius: 8px;
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
+  font-size: 14px;
+  line-height: 14px;
+  font-weight: ${({ theme }) => theme.fonts.WEIGHT.SEMIBOLD};
+  flex-shrink: 0;
+  width: fit-content;
 `;
 
 const ButtonDefaultInner = styled(ButtonInner)`
@@ -47,37 +44,29 @@ const ButtonDefaultInner = styled(ButtonInner)`
 const ButtonReverseInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GREEN[700]};
   background: ${({ theme }) => theme.colors.WHITE};
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[700]};
+  border: 1px solid ${({ theme }) => theme.colors.GREEN[700]};
   cursor: pointer;
-`;
-
-const ButtonOutlinedInner = styled(ButtonInner)`
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[200]};
-  background: ${({ theme }) => theme.colors.WHITE};
-  cursor: pointer;
-  &:hover {
-    border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  }
 `;
 
 const ButtonDisabledInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GRAY[100]};
+  background: ${({ theme }) => theme.colors.WHITE};
   border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  background: ${({ theme }) => theme.colors.GRAY[50]};
   cursor: not-allowed;
 `;
 
-const ButtonIconInner = styled(ButtonInner)`
-  color: ${({ theme }) => theme.colors.BLACK};
+const ButtonTextInner = styled(ButtonInner)`
+  text-align: center;
+  color: ${({ theme }) => theme.colors.GREEN[700]};
   cursor: pointer;
+  text-decoration-line: underline;
 `;
 
 const ButtonTypeInner = {
   default: ButtonDefaultInner,
   reverse: ButtonReverseInner,
-  outlined: ButtonOutlinedInner,
   disabled: ButtonDisabledInner,
-  icon: ButtonIconInner,
+  text: ButtonTextInner,
 };
 
 const ButtonWithTextInner = styled.div`
@@ -89,17 +78,6 @@ const ButtonWithTextInner = styled.div`
   display: inline-flex;
 `;
 
-const IconButton = (iconType: string) => (
-  <Icon type={iconType} size={18} color="black" />
-);
-
-const ButtonWithIconAndText = (iconType: string, buttonText: string) => (
-  <ButtonWithTextInner>
-    <Icon type={iconType} size={16} color="white" />
-    <Typography>{buttonText}</Typography>
-  </ButtonWithTextInner>
-);
-
 const ButtonWithText = (buttonText: string) => (
   <ButtonWithTextInner>
     <Typography>{buttonText}</Typography>
@@ -110,19 +88,16 @@ const ButtonWithChildren = (children: React.ReactNode) => (
   <ButtonWithTextInner>{children}</ButtonWithTextInner>
 );
 
-const Button = ({
+const MobileCompButton = ({
   type = "default",
   children = undefined,
-  iconType = "",
   buttonText = "",
 
   ...divProps
-}: ButtonProps) => {
+}: MobileCompButtonProps) => {
   const ButtonChosenInner = ButtonTypeInner[type];
 
   const ButtonContent = () => {
-    if (type === "icon") return IconButton(iconType);
-    if (iconType !== "") return ButtonWithIconAndText(iconType, buttonText);
     if (buttonText !== "") return ButtonWithText(buttonText);
     return ButtonWithChildren(children);
   };
@@ -137,4 +112,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default MobileCompButton;

--- a/packages/web/src/common/components/Buttons/MobileModalButton.tsx
+++ b/packages/web/src/common/components/Buttons/MobileModalButton.tsx
@@ -9,33 +9,30 @@ Custom Children을 넣고자 하면, iconType, buttonText 전달X
 
 "use client";
 
-/*
-
- */
-
 import React, { HTMLAttributes } from "react";
 import styled from "styled-components";
-import Icon from "@sparcs-students/web/common/components/Icon";
 import Typography from "@sparcs-students/web/common/components/Typography";
 
-type ButtonProps = {
+type MobileCompButtonProps = {
   type?: keyof typeof ButtonTypeInner;
   children?: React.ReactNode;
-  iconType?: string;
   buttonText?: string;
   onClick?: (() => void) | ((e: React.MouseEvent<HTMLDivElement>) => void);
 } & HTMLAttributes<HTMLDivElement>;
 
 const ButtonInner = styled.div`
-  display: inline-flex;
+  display: flex;
+  width: 100px;
+  height: 36px;
   padding: 8px 16px;
   justify-content: center;
   align-items: center;
-  border-radius: 4px;
+  border-radius: 8px;
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
+  font-size: 14px;
+  line-height: 14px;
+  font-weight: ${({ theme }) => theme.fonts.WEIGHT.SEMIBOLD};
+  flex-shrink: 0;
 `;
 
 const ButtonDefaultInner = styled(ButtonInner)`
@@ -47,37 +44,21 @@ const ButtonDefaultInner = styled(ButtonInner)`
 const ButtonReverseInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GREEN[700]};
   background: ${({ theme }) => theme.colors.WHITE};
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[700]};
+  border: 1px solid ${({ theme }) => theme.colors.GREEN[700]};
   cursor: pointer;
-`;
-
-const ButtonOutlinedInner = styled(ButtonInner)`
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[200]};
-  background: ${({ theme }) => theme.colors.WHITE};
-  cursor: pointer;
-  &:hover {
-    border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  }
 `;
 
 const ButtonDisabledInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GRAY[100]};
+  background: ${({ theme }) => theme.colors.WHITE};
   border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  background: ${({ theme }) => theme.colors.GRAY[50]};
   cursor: not-allowed;
-`;
-
-const ButtonIconInner = styled(ButtonInner)`
-  color: ${({ theme }) => theme.colors.BLACK};
-  cursor: pointer;
 `;
 
 const ButtonTypeInner = {
   default: ButtonDefaultInner,
   reverse: ButtonReverseInner,
-  outlined: ButtonOutlinedInner,
   disabled: ButtonDisabledInner,
-  icon: ButtonIconInner,
 };
 
 const ButtonWithTextInner = styled.div`
@@ -89,17 +70,6 @@ const ButtonWithTextInner = styled.div`
   display: inline-flex;
 `;
 
-const IconButton = (iconType: string) => (
-  <Icon type={iconType} size={18} color="black" />
-);
-
-const ButtonWithIconAndText = (iconType: string, buttonText: string) => (
-  <ButtonWithTextInner>
-    <Icon type={iconType} size={16} color="white" />
-    <Typography>{buttonText}</Typography>
-  </ButtonWithTextInner>
-);
-
 const ButtonWithText = (buttonText: string) => (
   <ButtonWithTextInner>
     <Typography>{buttonText}</Typography>
@@ -110,19 +80,16 @@ const ButtonWithChildren = (children: React.ReactNode) => (
   <ButtonWithTextInner>{children}</ButtonWithTextInner>
 );
 
-const Button = ({
+const MobileCompButton = ({
   type = "default",
   children = undefined,
-  iconType = "",
   buttonText = "",
 
   ...divProps
-}: ButtonProps) => {
+}: MobileCompButtonProps) => {
   const ButtonChosenInner = ButtonTypeInner[type];
 
   const ButtonContent = () => {
-    if (type === "icon") return IconButton(iconType);
-    if (iconType !== "") return ButtonWithIconAndText(iconType, buttonText);
     if (buttonText !== "") return ButtonWithText(buttonText);
     return ButtonWithChildren(children);
   };
@@ -137,4 +104,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default MobileCompButton;

--- a/packages/web/src/common/components/Buttons/ModalTableButton.tsx
+++ b/packages/web/src/common/components/Buttons/ModalTableButton.tsx
@@ -9,33 +9,32 @@ Custom Children을 넣고자 하면, iconType, buttonText 전달X
 
 "use client";
 
-/*
-
- */
-
 import React, { HTMLAttributes } from "react";
 import styled from "styled-components";
-import Icon from "@sparcs-students/web/common/components/Icon";
 import Typography from "@sparcs-students/web/common/components/Typography";
 
-type ButtonProps = {
+type ModalTableButtonProps = {
   type?: keyof typeof ButtonTypeInner;
   children?: React.ReactNode;
-  iconType?: string;
   buttonText?: string;
   onClick?: (() => void) | ((e: React.MouseEvent<HTMLDivElement>) => void);
 } & HTMLAttributes<HTMLDivElement>;
 
 const ButtonInner = styled.div`
-  display: inline-flex;
+  display: flex;
   padding: 8px 16px;
+  width: 60px;
+  height: 36px;
   justify-content: center;
   align-items: center;
+  text-align: center;
   border-radius: 4px;
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: ${({ theme }) => theme.fonts.WEIGHT.MEDIUM};
+  font-size: 14px;
+  line-height: 14px;
+  font-weight: ${({ theme }) => theme.fonts.WEIGHT.SEMIBOLD};
+  flex-shrink: 0;
+  white-space: nowrap;
 `;
 
 const ButtonDefaultInner = styled(ButtonInner)`
@@ -47,23 +46,13 @@ const ButtonDefaultInner = styled(ButtonInner)`
 const ButtonReverseInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GREEN[700]};
   background: ${({ theme }) => theme.colors.WHITE};
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[700]};
+  border: 1px solid ${({ theme }) => theme.colors.GREEN[700]};
   cursor: pointer;
-`;
-
-const ButtonOutlinedInner = styled(ButtonInner)`
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[200]};
-  background: ${({ theme }) => theme.colors.WHITE};
-  cursor: pointer;
-  &:hover {
-    border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  }
 `;
 
 const ButtonDisabledInner = styled(ButtonInner)`
-  color: ${({ theme }) => theme.colors.GRAY[100]};
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  background: ${({ theme }) => theme.colors.GRAY[50]};
+  color: ${({ theme }) => theme.colors.WHITE};
+  background: ${({ theme }) => theme.colors.GRAY[100]};
   cursor: not-allowed;
 `;
 
@@ -75,7 +64,6 @@ const ButtonIconInner = styled(ButtonInner)`
 const ButtonTypeInner = {
   default: ButtonDefaultInner,
   reverse: ButtonReverseInner,
-  outlined: ButtonOutlinedInner,
   disabled: ButtonDisabledInner,
   icon: ButtonIconInner,
 };
@@ -89,17 +77,6 @@ const ButtonWithTextInner = styled.div`
   display: inline-flex;
 `;
 
-const IconButton = (iconType: string) => (
-  <Icon type={iconType} size={18} color="black" />
-);
-
-const ButtonWithIconAndText = (iconType: string, buttonText: string) => (
-  <ButtonWithTextInner>
-    <Icon type={iconType} size={16} color="white" />
-    <Typography>{buttonText}</Typography>
-  </ButtonWithTextInner>
-);
-
 const ButtonWithText = (buttonText: string) => (
   <ButtonWithTextInner>
     <Typography>{buttonText}</Typography>
@@ -110,19 +87,16 @@ const ButtonWithChildren = (children: React.ReactNode) => (
   <ButtonWithTextInner>{children}</ButtonWithTextInner>
 );
 
-const Button = ({
+const ModalTableButton = ({
   type = "default",
   children = undefined,
-  iconType = "",
   buttonText = "",
 
   ...divProps
-}: ButtonProps) => {
+}: ModalTableButtonProps) => {
   const ButtonChosenInner = ButtonTypeInner[type];
 
   const ButtonContent = () => {
-    if (type === "icon") return IconButton(iconType);
-    if (iconType !== "") return ButtonWithIconAndText(iconType, buttonText);
     if (buttonText !== "") return ButtonWithText(buttonText);
     return ButtonWithChildren(children);
   };
@@ -137,4 +111,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default ModalTableButton;

--- a/packages/web/src/common/components/Buttons/PageButton.tsx
+++ b/packages/web/src/common/components/Buttons/PageButton.tsx
@@ -9,19 +9,13 @@ Custom Children을 넣고자 하면, iconType, buttonText 전달X
 
 "use client";
 
-/*
-
- */
-
 import React, { HTMLAttributes } from "react";
 import styled from "styled-components";
-import Icon from "@sparcs-students/web/common/components/Icon";
 import Typography from "@sparcs-students/web/common/components/Typography";
 
-type ButtonProps = {
+type PageButtonProps = {
   type?: keyof typeof ButtonTypeInner;
   children?: React.ReactNode;
-  iconType?: string;
   buttonText?: string;
   onClick?: (() => void) | ((e: React.MouseEvent<HTMLDivElement>) => void);
 } & HTMLAttributes<HTMLDivElement>;
@@ -29,6 +23,7 @@ type ButtonProps = {
 const ButtonInner = styled.div`
   display: inline-flex;
   padding: 8px 16px;
+  width: 100px;
   justify-content: center;
   align-items: center;
   border-radius: 4px;
@@ -47,23 +42,13 @@ const ButtonDefaultInner = styled(ButtonInner)`
 const ButtonReverseInner = styled(ButtonInner)`
   color: ${({ theme }) => theme.colors.GREEN[700]};
   background: ${({ theme }) => theme.colors.WHITE};
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[700]};
+  border: 1px solid ${({ theme }) => theme.colors.GREEN[700]};
   cursor: pointer;
-`;
-
-const ButtonOutlinedInner = styled(ButtonInner)`
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[200]};
-  background: ${({ theme }) => theme.colors.WHITE};
-  cursor: pointer;
-  &:hover {
-    border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  }
 `;
 
 const ButtonDisabledInner = styled(ButtonInner)`
-  color: ${({ theme }) => theme.colors.GRAY[100]};
-  border: 1px solid ${({ theme }) => theme.colors.GRAY[100]};
-  background: ${({ theme }) => theme.colors.GRAY[50]};
+  color: ${({ theme }) => theme.colors.WHITE};
+  background: ${({ theme }) => theme.colors.GRAY[100]};
   cursor: not-allowed;
 `;
 
@@ -75,7 +60,6 @@ const ButtonIconInner = styled(ButtonInner)`
 const ButtonTypeInner = {
   default: ButtonDefaultInner,
   reverse: ButtonReverseInner,
-  outlined: ButtonOutlinedInner,
   disabled: ButtonDisabledInner,
   icon: ButtonIconInner,
 };
@@ -89,17 +73,6 @@ const ButtonWithTextInner = styled.div`
   display: inline-flex;
 `;
 
-const IconButton = (iconType: string) => (
-  <Icon type={iconType} size={18} color="black" />
-);
-
-const ButtonWithIconAndText = (iconType: string, buttonText: string) => (
-  <ButtonWithTextInner>
-    <Icon type={iconType} size={16} color="white" />
-    <Typography>{buttonText}</Typography>
-  </ButtonWithTextInner>
-);
-
 const ButtonWithText = (buttonText: string) => (
   <ButtonWithTextInner>
     <Typography>{buttonText}</Typography>
@@ -110,19 +83,16 @@ const ButtonWithChildren = (children: React.ReactNode) => (
   <ButtonWithTextInner>{children}</ButtonWithTextInner>
 );
 
-const Button = ({
+const PageButton = ({
   type = "default",
   children = undefined,
-  iconType = "",
   buttonText = "",
 
   ...divProps
-}: ButtonProps) => {
+}: PageButtonProps) => {
   const ButtonChosenInner = ButtonTypeInner[type];
 
   const ButtonContent = () => {
-    if (type === "icon") return IconButton(iconType);
-    if (iconType !== "") return ButtonWithIconAndText(iconType, buttonText);
     if (buttonText !== "") return ButtonWithText(buttonText);
     return ButtonWithChildren(children);
   };
@@ -137,4 +107,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default PageButton;

--- a/packages/web/src/common/components/Buttons/TextButton.tsx
+++ b/packages/web/src/common/components/Buttons/TextButton.tsx
@@ -14,14 +14,20 @@ const StyledTextButton = styled.button.withConfig({
 })<ButtonProps>`
   background: none;
   border: none;
-  color: ${({ theme, disabled, white }) => {
+  color: ${({ theme, disabled, color, white }) => {
     if (disabled) return theme.colors.GRAY[100];
-    if (white) return theme.colors.WHITE;
+    if (color === "blue") {
+      return theme.colors.CYAN[700];
+    }
+    if (color === "red") {
+      return theme.colors.RED[500];
+    }
+    if (color === "white" || white) return theme.colors.WHITE;
     return theme.colors.PRIMARY;
   }};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
-  font-size: ${({ mini }) => (mini ? "12px" : "16px")};
-  line-height: ${({ mini }) => (mini ? "12px" : "20px")};
+  font-size: ${({ mini }) => (mini ? "12px" : "14px")};
+  line-height: ${({ mini }) => (mini ? "12px" : "14px")};
   font-weight: ${({ theme, light }) =>
     light ? theme.fonts.WEIGHT.REGULAR : theme.fonts.WEIGHT.MEDIUM};
   font-family: ${({ theme }) => theme.fonts.FAMILY.PRETENDARD};
@@ -35,6 +41,7 @@ interface TextButtonProps {
   light?: boolean;
   mini?: boolean;
   onClick?: () => void;
+  color?: string;
 }
 
 const TextButton: React.FC<TextButtonProps> = ({
@@ -44,6 +51,7 @@ const TextButton: React.FC<TextButtonProps> = ({
   light = false,
   mini = false,
   onClick = () => {},
+  color = "black",
 }) => (
   <StyledTextButton
     disabled={disabled}
@@ -51,6 +59,7 @@ const TextButton: React.FC<TextButtonProps> = ({
     light={light}
     onClick={onClick}
     mini={mini}
+    color={color}
   >
     {text}
   </StyledTextButton>

--- a/packages/web/src/common/components/Modal/CancellableModalContent.tsx
+++ b/packages/web/src/common/components/Modal/CancellableModalContent.tsx
@@ -1,7 +1,7 @@
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import React from "react";
 import styled from "styled-components";
 import Typography from "../Typography";
+import ModalTableButton from "../Buttons/ModalTableButton";
 
 interface CancellableModalContentProps {
   onClose: () => void;
@@ -39,19 +39,19 @@ const CancellableModalContent: React.FC<CancellableModalContentProps> = ({
       {children}
     </Typography>
     <ButtonWrapper>
-      <Button
-        type="outlined"
+      <ModalTableButton
+        type="reverse"
         onClick={onClose}
         style={{ fontSize: "14px", lineHeight: "12px" }}
       >
         {closeButtonText}
-      </Button>
-      <Button
+      </ModalTableButton>
+      <ModalTableButton
         onClick={onConfirm}
         style={{ fontSize: "14px", lineHeight: "12px" }}
       >
         {confirmButtonText}
-      </Button>
+      </ModalTableButton>
     </ButtonWrapper>
   </ModalContentInner>
 );

--- a/packages/web/src/common/components/Modal/ConfirmModalContent.tsx
+++ b/packages/web/src/common/components/Modal/ConfirmModalContent.tsx
@@ -1,6 +1,6 @@
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import React from "react";
 import styled from "styled-components";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 import Typography from "../Typography";
 
 interface ConfirmModalContentProps {
@@ -36,12 +36,12 @@ const ConfirmModalContent: React.FC<ConfirmModalContentProps> = ({
       {children}
     </Typography>
     <ButtonWrapper>
-      <Button
+      <ModalTableButton
         onClick={onConfirm}
         style={{ fontSize: "14px", lineHeight: "12px" }}
       >
         {confirmButtonText}
-      </Button>
+      </ModalTableButton>
     </ButtonWrapper>
   </ModalContentInner>
 );

--- a/packages/web/src/features/document-lookup/budget/frames/ReviewerBudgetProposalFrame.tsx
+++ b/packages/web/src/features/document-lookup/budget/frames/ReviewerBudgetProposalFrame.tsx
@@ -3,7 +3,6 @@
 import React, { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 
 import TotalTable from "@sparcs-students/web/features/document-lookup/budget/components/TotalTable";
 import {
@@ -23,6 +22,7 @@ import { dataToTotal } from "@sparcs-students/web/features/document-lookup/budge
 import { DocumentReviewStatusEnum } from "@sparcs-students/root/packages/interface/src/common/enum";
 import { mockViewBudgetProposalResultData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockViewResultData";
 import { mockDBExpenditureData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockManagerFormData";
+import PageButton from "@sparcs-students/web/common/components/Buttons/PageButton";
 
 const ButtonWrapper = styled.div`
   gap: 30px;
@@ -187,19 +187,19 @@ const ReviewerBudgetProposalFrame = () => {
       />
       <TotalTable data={dataToTotal(mockIncomeData, mockExpenditureData)} />
       <ButtonWrapper>
-        <Button
+        <PageButton
           type="reverse"
           onClick={openDiscardModal}
           style={{ width: "100px", padding: "8px 16px" }}
         >
           삭제
-        </Button>
-        <Button
+        </PageButton>
+        <PageButton
           onClick={openSaveModal}
           style={{ width: "100px", padding: "8px 16px" }}
         >
           제출
-        </Button>
+        </PageButton>
       </ButtonWrapper>
     </FlexWrapper>
   );

--- a/packages/web/src/features/document-lookup/components/DetailModal.tsx
+++ b/packages/web/src/features/document-lookup/components/DetailModal.tsx
@@ -1,8 +1,8 @@
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Typography from "@sparcs-students/web/common/components/Typography";
 import TextAreaInput from "@sparcs-students/web/common/components/Forms/TextAreaInput";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 
 interface DetailModalProps {
   onConfirm: () => void;
@@ -51,7 +51,7 @@ const DetailModal: React.FC<DetailModalProps> = ({
     </Typography>
     <DetailWrapper>{detail}</DetailWrapper>
     <ButtonWrapper>
-      <Button onClick={onConfirm}>닫기</Button>
+      <ModalTableButton onClick={onConfirm}>닫기</ModalTableButton>
     </ButtonWrapper>
   </ModalContentInner>
 );
@@ -82,22 +82,22 @@ export const EditableDetailModal: React.FC<EditableDetailModalProps> = ({
         handleChange={setLocalText}
       />
       <ButtonWrapper>
-        <Button // CHACHA: 디자인에는 없으나 필요할 것 같아서 넣음
+        <ModalTableButton // CHACHA: 디자인에는 없으나 필요할 것 같아서 넣음
           onClick={() => {
             onClose();
           }}
           type="reverse"
         >
           닫기
-        </Button>
-        <Button
+        </ModalTableButton>
+        <ModalTableButton
           onClick={() => {
             onChange(localText);
             onConfirm();
           }}
         >
           저장
-        </Button>
+        </ModalTableButton>
       </ButtonWrapper>
     </ModalContentInner>
   );

--- a/packages/web/src/features/document-lookup/components/ReviewModal.tsx
+++ b/packages/web/src/features/document-lookup/components/ReviewModal.tsx
@@ -1,9 +1,9 @@
-import Button from "@sparcs-students/web/common/components/Buttons/Button";
 import React, { useState } from "react";
 import styled, { useTheme } from "styled-components";
 import Typography from "@sparcs-students/web/common/components/Typography";
 import TextAreaInput from "@sparcs-students/web/common/components/Forms/TextAreaInput";
 import { DocumentReviewStatusEnum } from "@sparcs-students/root/packages/interface/src/common/enum/meeting.enum";
+import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
 
 interface ReviewModalProps {
   onConfirm: () => void;
@@ -70,11 +70,11 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
         value={reviewText}
       />
       <ButtonWrapper>
-        <Button onClick={onConfirm} type="reverse">
+        <ModalTableButton onClick={onConfirm} type="reverse">
           취소
-        </Button>
+        </ModalTableButton>
         <ThreeButtonWrapper>
-          <Button
+          <ModalTableButton
             onClick={() => {
               handleReviewChange(reviewText);
               handleStatusChange(DocumentReviewStatusEnum.ReviewRejected);
@@ -98,8 +98,8 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
             }
           >
             반려
-          </Button>
-          <Button
+          </ModalTableButton>
+          <ModalTableButton
             onClick={() => {
               handleReviewChange(reviewText);
               handleStatusChange(DocumentReviewStatusEnum.ReviseNeeded);
@@ -121,8 +121,8 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
             }
           >
             수정 요청
-          </Button>
-          <Button
+          </ModalTableButton>
+          <ModalTableButton
             onClick={() => {
               handleStatusChange(DocumentReviewStatusEnum.ReviewAccepted);
               onConfirm();
@@ -136,7 +136,7 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
             }
           >
             승인
-          </Button>
+          </ModalTableButton>
         </ThreeButtonWrapper>
       </ButtonWrapper>
     </ModalContentInner>
@@ -155,9 +155,9 @@ export const ReadOnlyReviewModal: React.FC<ReadOnlyReviewModalProps> = ({
     </Typography>
     <ContentWrapper>{review}</ContentWrapper>
     <ButtonWrapper>
-      <Button onClick={onConfirm} type="default">
+      <ModalTableButton onClick={onConfirm} type="default">
         닫기
-      </Button>
+      </ModalTableButton>
     </ButtonWrapper>
   </ModalContentInner>
 );

--- a/packages/web/src/features/document-lookup/project/services/getMockUserPermission.ts
+++ b/packages/web/src/features/document-lookup/project/services/getMockUserPermission.ts
@@ -1,5 +1,5 @@
 import { UserPermission } from "@sparcs-students/web/constants/userPermission";
 
-const getMockUserPermission = () => UserPermission.Manager; // 여기를 수정해서 테스트
+const getMockUserPermission = () => UserPermission.Reviewer; // 여기를 수정해서 테스트
 
 export default getMockUserPermission;


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #220 

버튼 모두 정리 완료했습니다.
이름들은 피그마 베이스로 했습니다.

먼저 정리해달라고 디자이너 분께서 요청하신
회원 등록, 학생회비, 총학 소개, 예결산 viewer, reviewer 중, 

- 회원 등록, 학생회비, 총학 소개는 아직 코드로 구현되지 않았거나 총학 소개의 경우에는 버튼을 쓰는 부분이 코드 상 없습니다. (그래서 안 건드림)
- 예결산 뷰어 리뷰어의 경우 페이지 제일 하단 삭제/제출 버튼과 조회 버튼 고쳤습니다. (모달은 나중에 정리하신다고 하셔서 안고쳤습니다)



/app/chacha/page.tsx 하나 만드셔서 정리된 버튼들 테스트 해보시면 스크린샷 처럼 나옵니다.

```
"use client";

import ModalTableButton from "@sparcs-students/web/common/components/Buttons/ModalTableButton";
import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
import PageButton from "@sparcs-students/web/common/components/Buttons/PageButton";
import TextButton from "@sparcs-students/web/common/components/Buttons/TextButton";
import CompButton from "@sparcs-students/web/common/components/Buttons/CompButton";
import MobileCompButton from "@sparcs-students/web/common/components/Buttons/MobileCompButton";
import MobileModalButton from "@sparcs-students/web/common/components/Buttons/MobileModalButton";

const Home = () => (
  <div>
    <h1>Button Components</h1>
    <FlexWrapper direction="row" gap={24}>
      <FlexWrapper direction="column" gap={8}>
        <p>These are comp buttons.</p>
        <CompButton type="default">운위 추가</CompButton>
        <CompButton type="reverse">운위 삭제</CompButton>
        <CompButton type="disabled">운위 삭제</CompButton>
      </FlexWrapper>
      <FlexWrapper direction="column" gap={8}>
        <p>These are page buttons.</p>
        <PageButton type="default">저장</PageButton>
        <PageButton type="reverse">이전</PageButton>
        <PageButton type="disabled">저장됨</PageButton>
      </FlexWrapper>
      <FlexWrapper direction="column" gap={8}>
        <p>These are modal-table buttons.</p>
        <ModalTableButton type="default">저장</ModalTableButton>
        <ModalTableButton type="reverse">이전</ModalTableButton>
        <ModalTableButton type="disabled">저장됨</ModalTableButton>
      </FlexWrapper>
      <FlexWrapper direction="column" gap={8}>
        <p>These are text buttons.</p>
        <TextButton text="승인" color="blue" />
        <TextButton text="반려" color="red" />
        <TextButton text="반려" disabled />
      </FlexWrapper>
    </FlexWrapper>
    <FlexWrapper direction="row" gap={24}>
      <FlexWrapper direction="column" gap={8}>
        <p>These are mobile comp buttons.</p>
        <MobileCompButton type="default">단체 가입</MobileCompButton>
        <MobileCompButton type="reverse">단체 가입</MobileCompButton>
        <MobileCompButton type="disabled">단체 가입</MobileCompButton>
        <MobileCompButton type="text">단체 가입</MobileCompButton>
      </FlexWrapper>
      <FlexWrapper direction="column" gap={8}>
        <p>These are mobile modal buttons.</p>
        <MobileModalButton type="default">저장</MobileModalButton>
        <MobileModalButton type="reverse">취소</MobileModalButton>
        <MobileModalButton type="disabled">저장</MobileModalButton>
      </FlexWrapper>
    </FlexWrapper>
  </div>
);

export default Home;
```



# 스크린샷
<img width="1497" alt="스크린샷 2025-05-23 오후 9 31 21" src="https://github.com/user-attachments/assets/a9c2a188-e351-4e96-a2bc-8de7722f9329" />


<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
