### PR TITLE
289 fix totalrow of budget table

### DIFF
--- a/packages/web/src/features/document-lookup/budget/frames/ViewerBudgetProposalFrame.tsx
+++ b/packages/web/src/features/document-lookup/budget/frames/ViewerBudgetProposalFrame.tsx
@@ -10,8 +10,7 @@ import {
   mockDBExpenditureData,
 } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockManagerFormData";
 
-// TotalTable용 mock 데이터는 별도로 import
-import { mockTotalData } from "@sparcs-students/web/features/document-lookup/budget/services/_mock/mockViewerReviewerBudgetData";
+import { dataToTotal } from "@sparcs-students/web/features/document-lookup/budget/util/dataToTotal";
 
 const ViewerBudgetProposalFrame = () => (
   <FlexWrapper direction="column" gap={48}>
@@ -25,7 +24,7 @@ const ViewerBudgetProposalFrame = () => (
       pageId="1"
     />
     {/* 통합 테이블 */}
-    <TotalTable data={mockTotalData} />
+    <TotalTable data={dataToTotal(mockDBIncomeData, mockDBExpenditureData)} />
   </FlexWrapper>
 );
 

--- a/packages/web/src/features/document-lookup/budget/util/dataToTotal.ts
+++ b/packages/web/src/features/document-lookup/budget/util/dataToTotal.ts
@@ -33,8 +33,8 @@ export const dataToTotal = (
         ...acc,
         [budgetDomain]: {
           ...prev,
-          incomeLastYear: prev.incomeLastYear + (lastYear as number),
-          incomeThisYear: prev.incomeThisYear + (thisYear as number),
+          incomeLastYear: prev.incomeLastYear + Number(lastYear),
+          incomeThisYear: prev.incomeThisYear + Number(thisYear),
         },
       };
     },
@@ -57,8 +57,8 @@ export const dataToTotal = (
       ...acc,
       [budgetDomain]: {
         ...prev,
-        expenditureLastYear: prev.expenditureLastYear + (lastYear as number),
-        expenditureThisYear: prev.expenditureThisYear + (thisYear as number),
+        expenditureLastYear: prev.expenditureLastYear + Number(lastYear),
+        expenditureThisYear: prev.expenditureThisYear + Number(thisYear),
       },
     };
   }, incomeMap);


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #289 
- dataToTotal 함수 내에서 테이블에 있는 숫자를 number가 아닌 string으로 계산하고 있어서 이를 수정했습니다.
- ViewerBudgetProposalFrame에서 총계 데이터를 불러오는 방법을 바꿨습니다. (단순 mock data 사용 --> dataToTotal 함수 사용)

# 스크린샷
<img width="2568" height="1089" alt="image" src="https://github.com/user-attachments/assets/b01c28d5-075b-4efc-ac1a-ffc10595c7ee" />
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
