### PR TITLE
fix: initialize content parameter of info page when entering through header

### DIFF
--- a/packages/web/src/app/info/page.tsx
+++ b/packages/web/src/app/info/page.tsx
@@ -4,7 +4,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import FlexWrapper from "@sparcs-students/web/common/components/FlexWrapper";
 import PageHead from "@sparcs-students/web/common/components/PageHead";
 import mockInfo from "@sparcs-students/web/features/info/mock";
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import Content from "@sparcs-students/web/features/info/components/Content";
 import styled from "styled-components";
 import Typography from "@sparcs-students/web/common/components/Typography";
@@ -23,19 +23,13 @@ const Info = () => {
 
   const matchingInfo = useMemo(() => {
     // content가 없으면 첫 번째 항목 반환
-    if (!content) {
-      router.replace(`/info?content=${mockInfo[0].category}`);
-      return mockInfo[0];
-    }
+    if (!content) return mockInfo[0];
 
     // content 파라미터에 해당하는 항목 찾기
     const mainItem = mockInfo.find(item => item.category === content);
 
     // content에 해당하는 항목이 없으면 첫 번째 항목 반환
-    if (!mainItem) {
-      router.replace(`/info?content=${mockInfo[0].category}`);
-      return mockInfo[0];
-    }
+    if (!mainItem) return mockInfo[0];
 
     // subContent 파라미터가 있고, 메인 항목에 subContent 배열이 있는 경우
     if (subContent && mainItem.subContent) {
@@ -51,6 +45,18 @@ const Info = () => {
     // subContent 파라미터가 없거나 메인 항목에 subContent 배열이 없는 경우 메인 항목 반환
     return mainItem;
   }, [content, subContent]);
+
+  useEffect(() => {
+    if (!content) {
+      router.replace(`/info?content=${mockInfo[0].category}`);
+      return;
+    }
+
+    const mainItem = mockInfo.find(item => item.category === content);
+    if (!mainItem) {
+      router.replace(`/info?content=${mockInfo[0].category}`);
+    }
+  }, [content, router]);
 
   return (
     <FlexWrapper direction="column" gap={48}>

--- a/packages/web/src/app/info/page.tsx
+++ b/packages/web/src/app/info/page.tsx
@@ -23,13 +23,19 @@ const Info = () => {
 
   const matchingInfo = useMemo(() => {
     // content가 없으면 첫 번째 항목 반환
-    if (!content) return mockInfo[0];
+    if (!content) {
+      router.replace(`/info?content=${mockInfo[0].category}`);
+      return mockInfo[0];
+    }
 
     // content 파라미터에 해당하는 항목 찾기
     const mainItem = mockInfo.find(item => item.category === content);
 
     // content에 해당하는 항목이 없으면 첫 번째 항목 반환
-    if (!mainItem) return mockInfo[0];
+    if (!mainItem) {
+      router.replace(`/info?content=${mockInfo[0].category}`);
+      return mockInfo[0];
+    }
 
     // subContent 파라미터가 있고, 메인 항목에 subContent 배열이 있는 경우
     if (subContent && mainItem.subContent) {


### PR DESCRIPTION
# 요약 \*

헤더를 통해 소개 페이지에 들어가면 자동으로 content parameter의 값이 첫번째 항목이 되도록 설정했습니다.

It closes #297 

# 스크린샷

<img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/2bbd0b09-8dae-4b45-9ee0-652d13755c87" />

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
