### PR TITLE
fix: align stage container start commands with actual build artifacts

### DIFF
--- a/.docker/dockerfile/web.Dockerfile
+++ b/.docker/dockerfile/web.Dockerfile
@@ -34,6 +34,7 @@ FROM base
 COPY --from=build /app/node_modules /app/node_modules
 COPY --from=build /app/packages/web /app/packages/web
 COPY --from=build /app/packages/interface /app/packages/interface
+COPY --from=build /app/tsconfig.json /app/tsconfig.json
 WORKDIR /app/packages/web
 
 EXPOSE 3000

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,7 +24,7 @@
     "migrate:dev": "pnpm db up --wait && pnpm drizzle-kit generate:mysql --config ./src/drizzle/drizzle.config.ts && pnpm ts-node src/drizzle/drizzle.migrate.ts",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/packages/api/src/main",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
## Summary

Stage 환경에서 web/api 두 컨테이너 모두 무한 재시작하는 문제 수정.

- **api**: `dist/main` 모듈을 못 찾아 `MODULE_NOT_FOUND`로 죽음. `packages/api/nest-cli.json`의 `entryFile: "packages/api/src/main"` 설정 때문에 nest 빌드 산출물이 `dist/packages/api/src/main.js`로 떨어지는데, `start:prod`는 `node dist/main`을 실행하고 있었음. 산출물 실제 경로로 정렬.
- **web**: 컨테이너 시작 시 `next build && next start` (= `pnpm build-start`)이 돌면서 `TS5083: Cannot read file '/app/tsconfig.json'`로 실패. `packages/web/tsconfig.json`이 `extends: "../../tsconfig.json"`인데 Dockerfile이 root tsconfig를 최종 이미지에 안 담고 있었음. 한 줄 추가해 복사.

## Background

이 두 버그가 그동안 안 터진 이유: stage 서버의 `/home/students/students-stage/redeploy-docker-login.sh`가 옛 organization 경로(`ghcr.io/academic-relations/...`)에서 14개월 된 이미지를 풀고 있어서 새 빌드가 실제로 stage에서 돌아간 적이 없었음. 서버 스크립트의 이미지 경로를 새 organization(`ghcr.io/sparcs-kaist/...`)으로 바꾸자마자 두 빌드 버그가 동시에 노출됨.

서버 측 redeploy 스크립트 경로 수정은 별도로 진행 (이 PR 범위 외).

## Test plan

- [ ] PR 머지 후 GitHub Actions의 `Students Dev Push Stage` 워크플로우가 새 이미지 빌드/푸시 성공
- [ ] stage 서버에서 redeploy 트리거 후 두 컨테이너가 `Restarting` 없이 `Up` 상태로 안정화
- [ ] `docker logs ar-007-students-stage-api`에 `MODULE_NOT_FOUND` 에러 없음
- [ ] `docker logs ar-007-students-stage-web`에 `TS5083` 에러 없음, Next.js가 정상 기동

🤖 Generated with [Claude Code](https://claude.com/claude-code)