### PR TITLE
fix: add express as direct dep of api

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -49,6 +49,7 @@
     "date-fns-tz": "^3.2.0",
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.30.9",
+    "express": "^5.1.0",
     "express-session": "^1.18.1",
     "mysql2": "^3.9.7",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       drizzle-orm:
         specifier: ^0.30.9
         version: 0.30.10(@types/react@18.3.20)(mysql2@3.14.0)(react@18.3.1)
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
       express-session:
         specifier: ^1.18.1
         version: 1.18.1
@@ -2286,7 +2289,7 @@ packages:
   '@mui/base@5.0.0-beta.38':
     resolution: {integrity: sha512-AsjD6Y1X5A1qndxz8xCcR8LDqv31aiwlgWMPxFAX/kCKiIGKlK65yMeVZ62iQr/6LBz+9hSKLiD1i4TZdAHKcQ==}
     engines: {node: '>=12.0.0'}
-    deprecated: This package has been replaced by @base-ui-components/react
+    deprecated: This package has been replaced by @base-ui/react
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
@@ -5407,6 +5410,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -6644,6 +6648,7 @@ packages:
   next@14.1.3:
     resolution: {integrity: sha512-oexgMV2MapI0UIWiXKkixF8J8ORxpy64OuJ/J9oVUmIthXOUCcuVEZX+dtpgq7wIfIqtBwQsKEDXejcjTsan9g==}
     engines: {node: '>=18.17.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -7798,7 +7803,7 @@ packages:
   superagent@8.1.2:
     resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superjson@2.2.2:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
@@ -7855,6 +7860,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telejson@7.2.0:
     resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}


### PR DESCRIPTION
## Summary

PR #321 머지 후에도 stage api 컨테이너가 `Cannot find module 'express'`로 죽는 문제 수정.

`packages/api/src/main.ts`와 여러 파일이 `express`를 직접 import하는데, 지금까지는 `@nestjs/platform-express`의 transitive dep으로만 들어와 있었음. pnpm의 isolated `node_modules` 구조에서는 transitive dep이 패키지 코드에서 직접 resolve되지 않으므로 런타임에 `MODULE_NOT_FOUND`로 깨짐.

`@nestjs/platform-express@11.0.17`가 이미 `express@5.1.0`을 가져오고 있어서 같은 메이저 라인(`^5.1.0`)으로 핀.

## Background

이 import는 #172 (openapi swagger PR, 2025-06-07)에서 들어왔는데, 그 시점부터 stage 서버가 academic-relations의 14개월 구버전 이미지만 풀고 있어서 production 빌드가 실제로 stage에서 돌아간 적이 없었음. PR #321이 머지되어 새 이미지가 배포되자마자 노출됨.

dev 환경에서 `nest start --watch`로 돌릴 때 안 깨지는 이유는 nest-cli가 dev 모드에서 다른 모듈 resolution path를 쓰기 때문 (production `node dist/...`와 다름).

## Test plan

- [ ] PR 머지 후 새 stage api 이미지 빌드/배포
- [ ] `docker logs ar-007-students-stage-api`에 `Cannot find module 'express'` 없이 정상 기동
- [ ] `/api/health` 또는 swagger UI(`/api/docs` 등) 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)