### PR TITLE
fix: copy monorepo root env folder into web image

### DIFF
--- a/.docker/dockerfile/web.Dockerfile
+++ b/.docker/dockerfile/web.Dockerfile
@@ -35,6 +35,7 @@ COPY --from=build /app/node_modules /app/node_modules
 COPY --from=build /app/packages/web /app/packages/web
 COPY --from=build /app/packages/interface /app/packages/interface
 COPY --from=build /app/tsconfig.json /app/tsconfig.json
+COPY --from=build /app/env /app/env
 WORKDIR /app/packages/web
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary

PR #321/#322 머지 후 web 컨테이너가 `Module not found: Can't resolve '@sparcs-students/root/env/dotenv-options'`로 빌드 실패하는 문제 수정.

`packages/web/src/env.ts`가 `@sparcs-students/root/env/dotenv-options`를 import하는데, 이 path alias는 `packages/web/tsconfig.json`의 `paths`에 의해 `../../env/dotenv-options` (= 컨테이너 안에서 `/app/env/dotenv-options.ts`)로 풀림. 그런데 web Dockerfile의 최종 스테이지가 `/app/env/`를 안 복사하고 있어서 런타임 `next build` 시 webpack이 모듈을 못 찾음.

한 줄 추가: `COPY --from=build /app/env /app/env`.

## Background

이 dotenv 셋업은 PR #320 (199-2-impl-login)에서 들어온 것으로 추정. web Dockerfile은 그 이후 업데이트가 안 됐고, stage 서버가 academic-relations 옛 이미지를 풀고 있어서 노출이 안 됐음.

api 쪽도 `packages/api/src/env.ts`에 동일 import가 있지만 main.ts/app.module.ts에서 import 체인에 들어있지 않아 현재 런타임에는 안 깨짐. 향후 누가 api/src/env를 import하면 같은 패턴으로 깨질 수 있으므로, api Dockerfile에도 같이 추가하는 게 안전하지만 이번 PR은 실제 깨진 web만 수정. 필요하면 후속 PR.

## Test plan

- [ ] PR 머지 후 새 web 이미지 빌드/배포
- [ ] `docker logs ar-007-students-stage-web`에 `Module not found` 없이 next build 통과, `next start`로 기동
- [ ] 페이지 접속 시 정상 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)