### PR TITLE
fix: use mysql connection pool to prevent closed-connection errors

### DIFF
--- a/packages/api/src/drizzle/drizzle.provider.ts
+++ b/packages/api/src/drizzle/drizzle.provider.ts
@@ -18,8 +18,12 @@ let connectionInstance = null;
 
 export const getConnection = async () => {
   if (!connectionInstance) {
-    connectionInstance = await mysql.createConnection({
+    connectionInstance = mysql.createPool({
       uri: env.DATABASE_URL,
+      connectionLimit: 10,
+      waitForConnections: true,
+      enableKeepAlive: true,
+      keepAliveInitialDelay: 0,
     });
   }
   return connectionInstance;


### PR DESCRIPTION
## Summary
- `packages/api/src/drizzle/drizzle.provider.ts`의 `mysql.createConnection()`을 `mysql.createPool()`로 교체하고 TCP keepalive를 활성화
- 장시간 idle 상태일 때 MySQL 서버 또는 중간 네트워크 장비(LB/NAT 등)가 단일 커넥션을 닫으면서 이후 모든 쿼리가 `Can't add new command when connection is in closed state`로 실패하던 문제 해결
- Pool은 죽은 커넥션을 자동으로 정리/재발급하므로 장기 가동 서버에 안전

## Test plan
- [x] 서버 기동 후 정상 쿼리 동작 확인
- [x] 장시간(>10분) idle 후 첫 요청이 에러 없이 처리되는지 확인
- [x] 동시 요청 시 pool에서 커넥션이 정상 분배되는지 확인 (connectionLimit=10)
- [x] 트랜잭션(`TransactionManagerService`) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)